### PR TITLE
Feature/node state alerts

### DIFF
--- a/nomad.toml.example
+++ b/nomad.toml.example
@@ -478,3 +478,49 @@ source = "wire-src"
 dest = "10.0.0.1"        # Private IP on direct cable
 path_type = "direct"
 user = "root"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# [signals.*] — Site policy for the insight engine's signal generators.
+#
+# These thresholds control what appears in the daily brief (nomad insights
+# brief) and on the dashboard. They are SEPARATE from [alerts.thresholds.*],
+# which controls the realtime dispatch path (email, Slack).
+#
+# Two namespaces, two purposes:
+#   [signals.*]            -> what shows in the brief / dashboard
+#   [alerts.thresholds.*]  -> what triggers immediate notifications
+#
+# Sites typically want both, often with the same values. Tune separately
+# when you want digest visibility without paging, or vice versa.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[signals.node_state]
+# State-string substrings (case-insensitive). Matching order:
+# ignore -> critical -> warning -> fallback (warning).
+#
+# Defaults cover Slurm composite states (e.g. "DOWN+NOT_RESPONDING",
+# "MIXED+DRAIN") and common vocabulary from PBS/Torque and LSF.
+critical_states  = ["DOWN", "NOT_RESPONDING", "FAIL", "OFFLINE", "UNREACH"]
+warning_states   = ["DRAIN", "DRNG", "DRAINING", "CLOSED", "UNAVAIL"]
+
+# States to never surface, even when the collector flags is_healthy=0.
+# Useful for sites that treat e.g. POWERED_DOWN as routine, not incident.
+ignore_states    = []
+
+# Fire a "multiple nodes unhealthy" rollup signal at the top of the brief
+# when more than this many nodes are currently unhealthy. Set high for
+# large clusters (5-10), low for small (1-2). Set 0 to disable.
+summary_threshold = 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# [alerts.node_state] — Realtime dispatch policy for node-state changes.
+# Mirrors [signals.node_state] but controls email/Slack/webhook dispatch.
+# Set enabled=false to skip dispatch entirely (the digest will still surface).
+# ─────────────────────────────────────────────────────────────────────────────
+
+[alerts.node_state]
+enabled = true
+critical_states = ["DOWN", "NOT_RESPONDING", "FAIL", "OFFLINE", "UNREACH"]
+warning_states  = ["DRAIN", "DRNG", "DRAINING", "CLOSED", "UNAVAIL"]
+ignore_states   = []

--- a/nomad/cli.py
+++ b/nomad/cli.py
@@ -3935,7 +3935,7 @@ def sync(ctx, config_file, output, dry_run):
     if hub_cfg is None:
         nomad_toml_path = Path.home() / '.config' / 'nomad' / 'nomad.toml'
         click.echo(click.style(
-            f"  No hub configuration found.", fg="red"))
+            "  No hub configuration found.", fg="red"))
         click.echo()
         click.echo(f"  Add a [hub] section to {nomad_toml_path}:")
         click.echo()

--- a/nomad/collectors/node_state.py
+++ b/nomad/collectors/node_state.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from .base import BaseCollector, CollectionError, registry
 
+from nomad.alerts import send_alert
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,35 +101,105 @@ class NodeStateCollector(BaseCollector):
 
     def __init__(self, config: dict[str, Any], db_path: str):
         super().__init__(config, db_path)
-
         self.nodes = config.get('nodes', None)  # None = all nodes
         self.cluster_name = config.get('cluster_name', 'default')
+        self._alert_config = config.get('alerts', {}).get('node_state', {})
         logger.info(f"NodeStateCollector: nodes={self.nodes or 'all'}")
+
+    # Default state policies. Used when [alerts.node_state] is absent from
+    # nomad.toml. Substring match (case-insensitive) covers Slurm composite
+    # states like "DOWN+NOT_RESPONDING" and "MIXED+DRAIN", plus common
+    # vocabulary from PBS ("down", "offline") and LSF ("unavail", "unreach").
+    DEFAULT_CRITICAL_STATES = ('DOWN', 'NOT_RESPONDING', 'FAIL', 'OFFLINE', 'UNREACH')
+    DEFAULT_WARNING_STATES = ('DRAIN', 'DRNG', 'DRAINING', 'CLOSED', 'UNAVAIL')
 
     def collect(self) -> list[dict[str, Any]]:
         """Collect node state from scontrol."""
-
         try:
             cmd = ['scontrol', 'show', 'node']
             if self.nodes:
                 cmd.append(','.join(self.nodes))
-
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 timeout=30,
             )
-
             if result.returncode != 0:
                 raise CollectionError(f"scontrol failed: {result.stderr}")
-
-            return self._parse_scontrol_output(result.stdout)
-
+            records = self._parse_scontrol_output(result.stdout)
+            if self._alert_config.get('enabled', True):
+                self._dispatch_state_alerts(records)
+            return records
         except FileNotFoundError:
             raise CollectionError("scontrol not found - SLURM not installed?")
         except subprocess.TimeoutExpired:
             raise CollectionError("scontrol timed out")
+
+    def _classify_state(self, state: str) -> str | None:
+        """
+        Return 'critical' | 'warning' | None for a state string.
+
+        None means the state is explicitly ignored (e.g. POWERED_DOWN at
+        sites that consider it operational, not an incident).
+
+        Configuration:
+            [alerts.node_state]
+            critical_states = ["DOWN", "NOT_RESPONDING", ...]
+            warning_states  = ["DRAIN", "DRNG", ...]
+            ignore_states   = ["POWERED_DOWN", ...]
+        """
+        s = (state or '').upper()
+        cfg = self._alert_config
+
+        ignore = [x.upper() for x in cfg.get('ignore_states', [])]
+        critical = [x.upper() for x in cfg.get('critical_states', self.DEFAULT_CRITICAL_STATES)]
+        warning = [x.upper() for x in cfg.get('warning_states', self.DEFAULT_WARNING_STATES)]
+
+        if any(tok in s for tok in ignore):
+            return None
+        if any(tok in s for tok in critical):
+            return 'critical'
+        if any(tok in s for tok in warning):
+            return 'warning'
+        return 'warning'  # is_healthy=0 but state unrecognized -> warn conservatively
+
+    def _dispatch_state_alerts(self, records: list[dict[str, Any]]) -> None:
+        """
+        Dispatch alerts for unhealthy nodes via the AlertDispatcher.
+
+        Deduplication is handled by the dispatcher's cooldown (same
+        source:host:severity within cooldown_minutes is suppressed),
+        so a node staying DOWN for hours sends one alert, not many.
+        """
+        for rec in records:
+            if rec.get('is_healthy', 1):
+                continue
+
+            severity = self._classify_state(rec.get('state', ''))
+            if severity is None:
+                continue  # explicitly ignored
+
+            node_name = rec.get('node_name', 'unknown')
+            reason = rec.get('reason') or 'no reason given'
+
+            try:
+                send_alert(
+                    severity=severity,
+                    source='node_state',
+                    message=f"Node {node_name} is {rec.get('state')} ({reason})",
+                    host=node_name,
+                    details={
+                        'state': rec.get('state'),
+                        'reason': reason,
+                        'cluster': rec.get('cluster', 'default'),
+                        'partitions': rec.get('partitions'),
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to dispatch node-state alert for {node_name}: {e}"
+                )
 
     def _parse_scontrol_output(self, output: str) -> list[dict[str, Any]]:
         """Parse scontrol show node output."""

--- a/nomad/collectors/per_user/ancestry.py
+++ b/nomad/collectors/per_user/ancestry.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Callable
+from collections.abc import Callable
 
 
 @dataclass(frozen=True)

--- a/nomad/collectors/per_user/collector.py
+++ b/nomad/collectors/per_user/collector.py
@@ -18,7 +18,8 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable
 
 try:
     import psutil

--- a/nomad/collectors/per_user/privileged.py
+++ b/nomad/collectors/per_user/privileged.py
@@ -94,7 +94,7 @@ def can_read_other_users_io() -> bool:
     # actually read it, we have the capability. /proc/1 is init/systemd,
     # owned by root.
     try:
-        with open("/proc/1/io", "r") as f:
+        with open("/proc/1/io") as f:
             f.read(64)
         return True
     except (PermissionError, FileNotFoundError, OSError):
@@ -241,7 +241,7 @@ def read_proc_io(pid: int) -> dict[str, int] | None:
     """
     path = f"/proc/{pid}/io"
     try:
-        with open(path, "r") as f:
+        with open(path) as f:
             data = f.read()
     except (PermissionError, FileNotFoundError, OSError):
         return None

--- a/nomad/collectors/per_user/rules.py
+++ b/nomad/collectors/per_user/rules.py
@@ -37,7 +37,8 @@ from __future__ import annotations
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Iterable, Literal
+from typing import Literal
+from collections.abc import Iterable
 
 
 RuleType = Literal["cpu", "memory"]

--- a/nomad/config/__init__.py
+++ b/nomad/config/__init__.py
@@ -20,6 +20,35 @@ def get_default_config_path() -> Path:
     """Get path to packaged default config."""
     return Path(__file__).parent / 'default.toml'
 
+def load_config(path: Path | None = None) -> dict:
+    """
+    Load NOMAD configuration as a dict.
+
+    Resolution order:
+      1. Explicit path argument
+      2. ~/.config/nomad/nomad.toml
+      3. /etc/nomad/nomad.toml
+      4. packaged default (nomad/config/default.toml)
+
+    Returns an empty dict if no config is found and the packaged default
+    can't be read — never raises, so callers can rely on it as a soft
+    accessor for site policy.
+    """
+    import tomllib  # 3.11+, stdlib
+    candidates: list[Path] = []
+    if path is not None:
+        candidates.append(Path(path))
+    candidates.extend(DEFAULT_CONFIG_PATHS)
+    candidates.append(get_default_config_path())
+
+    for p in candidates:
+        try:
+            if p.exists():
+                with p.open('rb') as f:
+                    return tomllib.load(f)
+        except Exception:
+            continue
+    return {}
 
 def resolve_cluster_name(config: dict) -> str:
     """Resolve cluster name from config, trying all known paths.

--- a/nomad/diag/workstation_prereqs.py
+++ b/nomad/diag/workstation_prereqs.py
@@ -75,7 +75,7 @@ class WorkstationPrereqDiagnostic:
     """Aggregate result of all prereq checks for one workstation."""
     hostname: str
     checks: list[DiagCheck] = field(default_factory=list)
-    ssh_user: Optional[str] = None
+    ssh_user: str | None = None
     ssh_reachable: bool = True
 
     @property
@@ -109,7 +109,7 @@ def _is_local(hostname: str) -> bool:
 def _run_remote(
     hostname: str,
     cmd: str,
-    ssh_user: Optional[str] = None,
+    ssh_user: str | None = None,
     timeout: int = 10,
 ) -> tuple[int, str, str]:
     """Run a shell command locally or over SSH.
@@ -148,7 +148,7 @@ def _run_remote(
 # Each check function takes (hostname, ssh_user) and returns a DiagCheck.
 # Each is independently testable; the orchestrator just composes them.
 
-def check_ssh_reachable(hostname: str, ssh_user: Optional[str]) -> DiagCheck:
+def check_ssh_reachable(hostname: str, ssh_user: str | None) -> DiagCheck:
     """Verify we can SSH to the workstation in the first place."""
     if _is_local(hostname):
         return DiagCheck(
@@ -173,7 +173,7 @@ def check_ssh_reachable(hostname: str, ssh_user: Optional[str]) -> DiagCheck:
     )
 
 
-def check_cgroup_v2_mounted(hostname: str, ssh_user: Optional[str]) -> DiagCheck:
+def check_cgroup_v2_mounted(hostname: str, ssh_user: str | None) -> DiagCheck:
     """Confirm /sys/fs/cgroup is a cgroup2 mount."""
     rc, out, err = _run_remote(
         hostname, "stat -fc %T /sys/fs/cgroup 2>&1", ssh_user,
@@ -197,7 +197,7 @@ def check_cgroup_v2_mounted(hostname: str, ssh_user: Optional[str]) -> DiagCheck
 
 
 def check_subtree_controllers(
-    hostname: str, ssh_user: Optional[str], scope_path: str, scope_label: str,
+    hostname: str, ssh_user: str | None, scope_path: str, scope_label: str,
 ) -> list[DiagCheck]:
     """Check which controllers are enabled in a given subtree_control file.
 
@@ -248,7 +248,7 @@ def check_subtree_controllers(
 
 
 def check_persistent_systemd_config(
-    hostname: str, ssh_user: Optional[str],
+    hostname: str, ssh_user: str | None,
 ) -> DiagCheck:
     """Verify the systemd manager config that keeps controllers enabled."""
     rc, out, err = _run_remote(
@@ -300,7 +300,7 @@ def check_persistent_systemd_config(
 
 
 def check_probe_runs(
-    hostname: str, ssh_user: Optional[str],
+    hostname: str, ssh_user: str | None,
 ) -> DiagCheck:
     """Run the deployed probe and confirm it returns valid JSON output."""
     cmd = (
@@ -358,7 +358,7 @@ def check_probe_runs(
 
 
 def check_psacct_installed(
-    hostname: str, ssh_user: Optional[str],
+    hostname: str, ssh_user: str | None,
 ) -> DiagCheck:
     """Process accounting (pacct) is optional but recommended."""
     rc, out, err = _run_remote(
@@ -519,8 +519,8 @@ def check_data_flow(
 
 def check_workstation_prerequisites(
     hostname: str,
-    ssh_user: Optional[str] = None,
-    db_path: Optional[str] = None,
+    ssh_user: str | None = None,
+    db_path: str | None = None,
 ) -> WorkstationPrereqDiagnostic:
     """Run all prereq checks and return aggregated result.
 

--- a/nomad/edu/insights.py
+++ b/nomad/edu/insights.py
@@ -126,7 +126,7 @@ class Issue:
     suggested_display: str = ""       # "4G", "18:00:00", "1"
     current_value_typical: float = 0.0  # modal/median of current requests
     current_display: str = ""         # "200 GB"
-    usage_stats: Optional[UsageStats] = None
+    usage_stats: UsageStats | None = None
     strategy: str = ""                # "mode" / "p95_with_buffer"
     rationale: str = ""               # explanation of how the value was chosen
 
@@ -153,7 +153,7 @@ class UserInsights:
 
 # ── Configuration ────────────────────────────────────────────────────
 
-def _load_thresholds(config: Optional[dict[str, Any]] = None) -> dict[str, float]:
+def _load_thresholds(config: dict[str, Any] | None = None) -> dict[str, float]:
     """Load thresholds from config, falling back to defaults."""
     thresholds = dict(DEFAULT_THRESHOLDS)
     if config and isinstance(config.get("thresholds"), dict):
@@ -225,7 +225,7 @@ def _aggregate_quantile(
     return suggested_value, f"p{pct_label}_with_{buffer_factor:g}x_buffer", rationale
 
 
-def _build_usage_stats(suggestions: list[Suggestion]) -> Optional[UsageStats]:
+def _build_usage_stats(suggestions: list[Suggestion]) -> UsageStats | None:
     """Compute the distribution of actual_usage across suggestions."""
     usages = [s.actual_usage for s in suggestions if s.actual_usage > 0]
     if not usages:
@@ -308,7 +308,7 @@ def _aggregate_dimension(
     dim_key: str,
     fingerprints: list[JobFingerprint],
     threshold: float,
-) -> Optional[Issue]:
+) -> Issue | None:
     """Build an Issue for one dimension, or None if not systemic."""
     dim_name = KEY_TO_DISPLAY.get(dim_key, dim_key)
     affected_scores: list[float] = []
@@ -425,7 +425,7 @@ def user_insights(
     db_path: str,
     username: str,
     days: int = 90,
-    config: Optional[dict[str, Any]] = None,
+    config: dict[str, Any] | None = None,
 ) -> UserInsights:
     """
     Compute systemic insights for a user across recent jobs.
@@ -516,7 +516,7 @@ def format_user_insights(insights: UserInsights, detailed: bool = False) -> str:
         lines.append("  to flag any single dimension.")
         return "\n".join(lines)
 
-    lines.append(f"  Top issues across your recent jobs:")
+    lines.append("  Top issues across your recent jobs:")
     lines.append(f"  {'─' * 56}")
 
     for issue in insights.issues:
@@ -567,10 +567,10 @@ def format_user_insights(insights: UserInsights, detailed: bool = False) -> str:
     if not detailed:
         lines.append("")
         lines.append(
-            f"  Run with --detailed for per-dimension trajectory and details."
+            "  Run with --detailed for per-dimension trajectory and details."
         )
         lines.append(
-            f"  Run `nomad edu explain <job_id>` for a single-job analysis."
+            "  Run `nomad edu explain <job_id>` for a single-job analysis."
         )
 
     return "\n".join(lines)

--- a/nomad/edu/progress.py
+++ b/nomad/edu/progress.py
@@ -23,8 +23,10 @@ from datetime import datetime, timedelta
 
 from nomad.edu.scoring import (
     JobFingerprint,
+    SessionFingerprint,
     bar,
     score_job,
+    score_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -164,6 +166,114 @@ def _score_jobs(rows: list[dict]) -> list[JobFingerprint]:
             logger.debug(f"Could not score job {row.get('job_id')}: {e}")
     return fingerprints
 
+
+
+def _load_user_sessions(
+    db_path: str,
+    username: str,
+    days: int = 7,
+) -> list[dict]:
+    """
+    Load a user's workstation sessions with host capacity, for scoring.
+
+    Aggregates workstation_user_snapshot rows by session_epoch into one
+    row per session. Joins to the latest workstation_state per host so
+    each row carries the host's capacity (memory_total_mb, cpu_count) at
+    scoring time.
+
+    Filters uid >= 1000 to exclude system accounts (root, dbus, etc.).
+    Workstation snapshots churn faster than cluster jobs, so the default
+    window is shorter (7 days vs 90).
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cutoff = (datetime.now() - timedelta(days=days)).isoformat()
+        rows = conn.execute("""
+            WITH latest_state AS (
+              SELECT hostname, memory_total_mb, cpu_count,
+                     ROW_NUMBER() OVER (
+                         PARTITION BY hostname ORDER BY timestamp DESC
+                     ) AS rn
+              FROM workstation_state
+            ),
+            session_agg AS (
+              SELECT hostname, username, uid, session_epoch,
+                     MAX(memory_peak_bytes) AS peak_memory_bytes,
+                     MAX(cpu_usage_usec)    AS cpu_usage_usec,
+                     MIN(timestamp)         AS first_seen,
+                     MAX(timestamp)         AS last_seen,
+                     COUNT(*)               AS samples
+              FROM workstation_user_snapshot
+              WHERE timestamp >= ?
+                AND uid >= 1000
+                AND username = ?
+              GROUP BY hostname, username, uid, session_epoch
+            )
+            SELECT s.hostname, s.username, s.uid, s.session_epoch,
+                   s.peak_memory_bytes, s.cpu_usage_usec,
+                   s.first_seen, s.last_seen, s.samples,
+                   (julianday(s.last_seen) - julianday(s.first_seen)) * 24
+                       AS span_hours,
+                   ls.memory_total_mb AS host_memory_total_mb,
+                   ls.cpu_count       AS host_cpu_count
+            FROM session_agg s
+            LEFT JOIN latest_state ls
+                ON ls.hostname = s.hostname AND ls.rn = 1
+            ORDER BY s.last_seen ASC
+        """, (cutoff, username)).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        logger.error(f"Error loading sessions for {username}: {e}")
+        return []
+
+
+def _split_session_fields(row: dict) -> tuple[dict, dict]:
+    """Split a joined session+host_state row into session and host_state dicts.
+
+    Parallel to _split_job_fields. The session scorer expects
+    score_session(session, host_state) with host capacity as a separate
+    arg, not nested in the session dict.
+    """
+    session = {
+        "username":          row.get("username"),
+        "hostname":          row.get("hostname"),
+        "session_epoch":     row.get("session_epoch"),
+        "peak_memory_bytes": row.get("peak_memory_bytes"),
+        "cpu_usage_usec":    row.get("cpu_usage_usec"),
+        "samples":           row.get("samples"),
+        "span_hours":        row.get("span_hours"),
+    }
+    host_state = {
+        "hostname":        row.get("hostname"),
+        "memory_total_mb": row.get("host_memory_total_mb"),
+        "cpu_count":       row.get("host_cpu_count"),
+    }
+    return session, host_state
+
+
+def _score_sessions(rows: list[dict]) -> list[SessionFingerprint]:
+    """Score a list of joined session+host_state rows.
+
+    Parallel to _score_jobs: thin wrapper, per-row exception handling so
+    one bad row doesn't kill the batch, attaches _last_seen for
+    trajectory ordering (matches the _end_time pattern on JobFingerprint).
+    """
+    fingerprints = []
+    for row in rows:
+        session, host_state = _split_session_fields(row)
+        try:
+            fp = score_session(session, host_state)
+            fp._last_seen = row.get("last_seen", "")
+            fingerprints.append(fp)
+        except Exception as e:
+            logger.debug(
+                f"Could not score session "
+                f"{row.get('hostname')}/{row.get('username')}/"
+                f"{row.get('session_epoch')}: {e}"
+            )
+    return fingerprints
 
 def user_trajectory(
     db_path: str,

--- a/nomad/edu/scoring.py
+++ b/nomad/edu/scoring.py
@@ -675,6 +675,233 @@ def score_gpu(job: dict, summary: dict) -> DimensionScore:
 
 # ── Top-level scorer ─────────────────────────────────────────────────
 
+
+# ── Workstation scoring ──────────────────────────────────────────────
+#
+# Parallel to job scoring above. A "session" is to a workstation what a
+# "job" is to a cluster: a bounded unit of use we can score for health.
+# Identified by (hostname, username, session_epoch) in
+# workstation_user_snapshot.
+#
+# Dimensions describe session health (memory pressure, duration fit).
+# Cross-cutting verdicts like "you should be on the cluster" are NOT
+# dimensions — they live in insights.py and are derived from the
+# co-occurrence of these dimensional findings. See B2 decision in
+# v1.7.0 design notes.
+
+
+# Smallest-fit cluster memory tiers (MB). Sourced from node_state on
+# spydur as of 2026-05. Ideally pulled live at runtime; constant here
+# keeps the scorer DB-free for testability.
+SPYDUR_MEMORY_TIERS_MB: tuple[int, ...] = (384_000, 768_000, 1_536_000)
+
+
+@dataclass
+class SessionFingerprint:
+    """Complete proficiency fingerprint for a single workstation session."""
+    username: str
+    hostname: str
+    session_epoch: int
+    dimensions: dict[str, DimensionScore] = field(default_factory=dict)
+
+    @property
+    def overall(self) -> float:
+        """Weighted average of applicable dimensions."""
+        applicable = [d for d in self.dimensions.values() if d.applicable]
+        if not applicable:
+            return 0.0
+        return sum(d.score for d in applicable) / len(applicable)
+
+    @property
+    def overall_level(self) -> str:
+        return proficiency_level(self.overall)
+
+    @property
+    def needs_work(self) -> list[DimensionScore]:
+        """Dimensions that need improvement, worst first."""
+        return sorted(
+            [d for d in self.dimensions.values()
+             if d.applicable and d.score < 65],
+            key=lambda d: d.score,
+        )
+
+    @property
+    def strengths(self) -> list[DimensionScore]:
+        """Dimensions showing good proficiency."""
+        return [d for d in self.dimensions.values()
+                if d.applicable and d.score >= 65]
+
+
+def score_memory_pressure(session: dict, host_state: dict) -> DimensionScore:
+    """
+    Score memory pressure on a workstation session.
+
+    Unlike cluster score_memory (where low utilization is wasteful), here
+    high utilization is the bad signal: a workstation is shared with
+    other users and the OS, and a session consuming most of host RAM
+    starves everything else.
+
+    Scoring (peak / host_total):
+        <40%   → Excellent (plenty of headroom)
+        40-65% → Good
+        65-85% → Developing (noticeable pressure)
+        >85%   → Needs Work (sustained near-saturation)
+    """
+    peak_bytes = session.get("peak_memory_bytes") or 0
+    host_mb = host_state.get("memory_total_mb") or 0
+
+    if peak_bytes <= 0 or host_mb <= 0:
+        return DimensionScore(
+            name="Memory Pressure",
+            score=50,
+            level="Unknown",
+            detail="No memory snapshot data available for this session.",
+            applicable=False,
+        )
+
+    peak_mb = peak_bytes / 1024 / 1024
+    pressure = peak_mb / host_mb  # 0..1+ (can exceed 1.0 if cgroup peak
+                                  # includes cache/buffers beyond RSS)
+    pressure_pct = pressure * 100
+
+    # Score: inverse of pressure, clamped 0..100.
+    # 0% pressure → 100; 100% pressure → 0; linear between.
+    score = max(0, min(100, 100 * (1 - pressure)))
+
+    peak_gb = peak_mb / 1024
+    host_gb = host_mb / 1024
+
+    if score >= 85:
+        detail = (f"Comfortable headroom. Peaked at {peak_gb:.1f}GB of "
+                  f"{host_gb:.0f}GB host RAM ({pressure_pct:.0f}%).")
+    elif score >= 65:
+        detail = (f"Moderate memory use. Peaked at {peak_gb:.1f}GB of "
+                  f"{host_gb:.0f}GB host RAM ({pressure_pct:.0f}%).")
+    elif score >= 40:
+        detail = (f"Noticeable memory pressure. Peaked at {peak_gb:.1f}GB "
+                  f"of {host_gb:.0f}GB host RAM ({pressure_pct:.0f}%); "
+                  f"other users on this host have less to work with.")
+    else:
+        detail = (f"Sustained memory pressure. Peaked at {peak_gb:.1f}GB "
+                  f"of {host_gb:.0f}GB host RAM ({pressure_pct:.0f}%). "
+                  f"At this level the workstation is effectively yours; "
+                  f"other users will see slowdowns.")
+
+    # No Suggestion attached: the actionable recommendation
+    # ("move to spydur") is a cross-cutting verdict produced in
+    # insights.py, not a per-dimension tuning suggestion.
+    return DimensionScore(
+        name="Memory Pressure",
+        score=round(score, 1),
+        level=proficiency_level(score),
+        detail=detail,
+        suggestion=None,
+    )
+
+
+def score_duration_fit(session: dict, host_state: dict) -> DimensionScore:
+    """
+    Score whether a session's duration fits its substrate.
+
+    Short sessions are always fine; long sessions on a workstation are
+    a smell even when memory is comfortable, because they tie up an
+    interactive resource that should be available to other users.
+
+    Piecewise score on span_hours:
+        ≤2h   → 100
+        2-6h  → linear taper 100 → 60
+        6-18h → linear taper 60 → 30
+        ≥18h  → 10 (floor)
+    """
+    span_hours = session.get("span_hours")
+    if span_hours is None or span_hours < 0:
+        return DimensionScore(
+            name="Session Duration",
+            score=50,
+            level="Unknown",
+            detail="No session duration data available.",
+            applicable=False,
+        )
+
+    if span_hours <= 2:
+        score = 100.0
+    elif span_hours <= 6:
+        # 2h → 100, 6h → 60
+        score = 100 - (span_hours - 2) * (40 / 4)
+    elif span_hours <= 18:
+        # 6h → 60, 18h → 30
+        score = 60 - (span_hours - 6) * (30 / 12)
+    else:
+        score = 10.0
+
+    if score >= 85:
+        detail = (f"Session ran for {span_hours:.1f}h — typical "
+                  f"interactive use.")
+    elif score >= 65:
+        detail = (f"Session ran for {span_hours:.1f}h — extended but "
+                  f"reasonable for a workstation.")
+    elif score >= 40:
+        detail = (f"Session ran for {span_hours:.1f}h. Long enough that "
+                  f"a batch job on the cluster would have been a "
+                  f"reasonable alternative.")
+    else:
+        detail = (f"Session ran for {span_hours:.1f}h. Workloads this "
+                  f"long are what the cluster is for: jobs survive "
+                  f"disconnects, reboots, and competing users.")
+
+    return DimensionScore(
+        name="Session Duration",
+        score=round(score, 1),
+        level=proficiency_level(score),
+        detail=detail,
+        suggestion=None,
+    )
+
+
+def score_session(session: dict, host_state: dict) -> SessionFingerprint:
+    """
+    Build a complete fingerprint for one workstation session.
+
+    Parallel to score_job. Takes the session record (one row from
+    workstation_user_snapshot, augmented with derived span_hours from
+    grouping by session_epoch) and the workstation_state snapshot for
+    its host.
+    """
+    return SessionFingerprint(
+        username=session.get("username", ""),
+        hostname=session.get("hostname", ""),
+        session_epoch=session.get("session_epoch", 0),
+        dimensions={
+            "memory_pressure": score_memory_pressure(session, host_state),
+            "duration_fit":    score_duration_fit(session, host_state),
+        },
+    )
+
+
+def select_cluster_target(
+    peak_mb: float,
+    host_mb: int,
+    tiers: tuple[int, ...] = SPYDUR_MEMORY_TIERS_MB,
+) -> Optional[tuple[int, float]]:
+    """
+    Pick the smallest cluster memory tier that gives meaningful headroom.
+
+    Rule: smallest tier that is BOTH (a) ≥ peak_mb × 1.5 and (b) ≥ 2× host
+    workstation RAM. The 2× host rule prevents recommending a near-equal
+    box ("move from 256GB to 384GB" is not a real upgrade).
+
+    Returns (target_mb, ratio_vs_host) or None if no tier qualifies.
+    """
+    if peak_mb <= 0 or host_mb <= 0:
+        return None
+    needed = peak_mb * 1.5
+    min_meaningful = host_mb * 2
+    threshold = max(needed, min_meaningful)
+    for tier in sorted(tiers):
+        if tier >= threshold:
+            return tier, tier / host_mb
+    return None
+
 def score_job(job: dict, summary: dict) -> JobFingerprint:
     """Score a job across all five dimensions."""
     fp = JobFingerprint(

--- a/nomad/edu/scoring.py
+++ b/nomad/edu/scoring.py
@@ -202,7 +202,7 @@ class DimensionScore:
     score: float                          # 0-100
     level: str                            # Excellent/Good/Developing/Needs Work
     detail: str                           # Human-readable explanation
-    suggestion: Optional[Suggestion] = None
+    suggestion: Suggestion | None = None
     applicable: bool = True               # False if dimension doesn't apply
 
     @property
@@ -436,8 +436,8 @@ def score_memory(job: dict, summary: dict) -> DimensionScore:
             current_value=req_mem_mb,
             actual_usage=peak_mem_gb * 1024,
             unit="MB",
-            rationale=(f"memory you don't use is unavailable to other jobs "
-                       f"on the node"),
+            rationale=("memory you don't use is unavailable to other jobs "
+                       "on the node"),
         )
 
     return DimensionScore(
@@ -882,7 +882,7 @@ def select_cluster_target(
     peak_mb: float,
     host_mb: int,
     tiers: tuple[int, ...] = SPYDUR_MEMORY_TIERS_MB,
-) -> Optional[tuple[int, float]]:
+) -> tuple[int, float] | None:
     """
     Pick the smallest cluster memory tier that gives meaningful headroom.
 

--- a/nomad/insights/signals.py
+++ b/nomad/insights/signals.py
@@ -16,6 +16,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class SignalType(Enum):
     """Categories of operational signals."""
@@ -117,7 +120,7 @@ def create_site_db(db_path: Path, site: str) -> Path:
     return tmp_path
 
 
-def read_job_signals(db_path: Path, hours: int = 24) -> list[Signal]:
+def read_job_signals(db_path: Path, hours: int = 24, config: dict | None = None) -> list[Signal]:
     """Analyze recent job outcomes for failure patterns."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -243,7 +246,7 @@ def read_job_signals(db_path: Path, hours: int = 24) -> list[Signal]:
 
 # ── Disk / storage signals ───────────────────────────────────────────────
 
-def read_disk_signals(db_path: Path, hours: int = 6) -> list[Signal]:
+def read_disk_signals(db_path: Path, hours: int = 6, config: dict | None = None) -> list[Signal]:
     """Check storage filesystem trends."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -427,7 +430,7 @@ def read_disk_signals(db_path: Path, hours: int = 6) -> list[Signal]:
 
 # ── GPU signals ──────────────────────────────────────────────────────────
 
-def read_gpu_signals(db_path: Path, hours: int = 24) -> list[Signal]:
+def read_gpu_signals(db_path: Path, hours: int = 24, config: dict | None = None) -> list[Signal]:
     """Analyze GPU utilization and memory patterns."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -478,7 +481,7 @@ def read_gpu_signals(db_path: Path, hours: int = 24) -> list[Signal]:
 
 # ── Queue signals ────────────────────────────────────────────────────────
 
-def read_queue_signals(db_path: Path, hours: int = 6) -> list[Signal]:
+def read_queue_signals(db_path: Path, hours: int = 6, config: dict | None = None) -> list[Signal]:
     """Analyze job queue pressure and wait times."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -550,7 +553,7 @@ def read_queue_signals(db_path: Path, hours: int = 6) -> list[Signal]:
 
 # ── Network signals ──────────────────────────────────────────────────────
 
-def read_network_signals(db_path: Path, hours: int = 6) -> list[Signal]:
+def read_network_signals(db_path: Path, hours: int = 6, config: dict | None = None) -> list[Signal]:
     """Check for network anomalies."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -598,7 +601,7 @@ def read_network_signals(db_path: Path, hours: int = 6) -> list[Signal]:
 
 # ── Alert signals ────────────────────────────────────────────────────────
 
-def read_alert_signals(db_path: Path, hours: int = 24) -> list[Signal]:
+def read_alert_signals(db_path: Path, hours: int = 24, config: dict | None = None) -> list[Signal]:
     """Read active/recent alerts from the alerts table."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -675,7 +678,7 @@ def read_alert_signals(db_path: Path, hours: int = 24) -> list[Signal]:
 
 # ── Cloud signals ────────────────────────────────────────────────────────
 
-def read_cloud_signals(db_path: Path, hours: int = 24) -> list[Signal]:
+def read_cloud_signals(db_path: Path, hours: int = 24, config: dict | None = None) -> list[Signal]:
     """Analyze cloud instance metrics for cost and performance signals."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -725,10 +728,117 @@ def read_cloud_signals(db_path: Path, hours: int = 24) -> list[Signal]:
 
     return signals
 
+def read_node_health_signals(
+    db_path: Path,
+    hours: int = 24,
+    config: dict | None = None,
+) -> list[Signal]:
+    """
+    Surface currently unhealthy nodes from the latest node_state samples.
+
+    Independent of the alerts table: queries node_state directly so the
+    digest catches node issues even when alert dispatch is unconfigured.
+
+    Configuration (nomad.toml):
+        [signals.node_state]
+        critical_states = [...]   # substrings -> critical signals
+        warning_states  = [...]   # substrings -> warning signals
+        ignore_states   = [...]   # never surface these states
+        summary_threshold = 3     # multi-node rollup fires above this count
+                                  # (0 disables the rollup signal)
+    """
+    cfg = (config or {}).get('signals', {}).get('node_state', {})
+    critical = [x.upper() for x in cfg.get('critical_states',
+                ['DOWN', 'NOT_RESPONDING', 'FAIL', 'OFFLINE', 'UNREACH'])]
+    warning = [x.upper() for x in cfg.get('warning_states',
+                ['DRAIN', 'DRNG', 'DRAINING', 'CLOSED', 'UNAVAIL'])]
+    ignore = [x.upper() for x in cfg.get('ignore_states', [])]
+    summary_threshold = cfg.get('summary_threshold', 3)
+
+    signals: list[Signal] = []
+    conn = _get_conn(db_path)
+
+    try:
+        rows = conn.execute("""
+            SELECT node_name, state, reason, cluster, partitions, timestamp
+            FROM node_state
+            WHERE (node_name, timestamp) IN (
+                SELECT node_name, MAX(timestamp)
+                FROM node_state
+                GROUP BY node_name
+            )
+              AND is_healthy = 0
+            ORDER BY node_name
+        """).fetchall()
+
+        if not rows:
+            return signals
+
+        crit_count = 0
+        for r in rows:
+            state = (r["state"] or "").upper()
+            if any(tok in state for tok in ignore):
+                continue
+
+            if any(tok in state for tok in critical):
+                sev = Severity.CRITICAL
+                title = "node_down"
+                crit_count += 1
+            elif any(tok in state for tok in warning):
+                sev = Severity.WARNING
+                title = "node_drain"
+            else:
+                sev = Severity.WARNING
+                title = "node_unhealthy"
+
+            node = r["node_name"]
+            cluster = r["cluster"] or "default"
+            reason = r["reason"] or "no reason given"
+            part = r["partitions"] or ""
+
+            detail = f"Node {node} is {state} on {cluster}"
+            if part:
+                detail += f" ({part} partition)"
+            detail += f"; reason: {reason}"
+
+            signals.append(Signal(
+                signal_type=SignalType.ALERT,
+                severity=sev,
+                title=title,
+                detail=detail,
+                metrics={
+                    "node": node,
+                    "state": state,
+                    "reason": reason,
+                    "cluster": cluster,
+                    "partitions": part,
+                    "last_seen": r["timestamp"],
+                },
+            ))
+
+        # Multi-node rollup. Fires when too many nodes are unhealthy at once.
+        # Threshold is site-tunable: small clusters set 1-2, large clusters 5-10.
+        if summary_threshold > 0 and len(signals) > summary_threshold:
+            signals.insert(0, Signal(
+                signal_type=SignalType.ALERT,
+                severity=Severity.CRITICAL if crit_count else Severity.WARNING,
+                title="multiple_nodes_unhealthy",
+                detail=(f"{len(signals)} nodes currently unhealthy "
+                        f"({crit_count} critical). Cluster capacity reduced."),
+                metrics={
+                    "total_unhealthy": len(signals),
+                    "critical_count": crit_count,
+                    "warning_count": len(signals) - crit_count,
+                },
+            ))
+    finally:
+        conn.close()
+
+    return signals
 
 # ── Workstation signals ──────────────────────────────────────────────────
 
-def read_workstation_signals(db_path: Path, hours: int = 6) -> list[Signal]:
+def read_workstation_signals(db_path: Path, hours: int = 6, config: dict | None = None) -> list[Signal]:
     """Check workstation health from workstation_state table."""
     signals: list[Signal] = []
     conn = _get_conn(db_path)
@@ -1031,7 +1141,7 @@ def _read_dynamics_for_site(
     return signals
 
 # ── Master reader ────────────────────────────────────────────────────────
-def read_dynamics_signals(db_path: Path, hours: int = 168) -> list[Signal]:
+def read_dynamics_signals(db_path: Path, hours: int = 168, config: dict | None = None) -> list[Signal]:
     """Read system dynamics metrics per-cluster."""
     # Detect multi-site (combined) database
     conn = _get_conn(db_path)
@@ -1068,28 +1178,47 @@ def read_dynamics_signals(db_path: Path, hours: int = 168) -> list[Signal]:
             db_path, hours)
 
 
-def read_all_signals(db_path: Path, hours: int = 24) -> list[Signal]:
-    """Run all signal readers and return combined results."""
+def read_all_signals(
+    db_path: Path,
+    hours: int = 24,
+    config: dict | None = None,
+) -> list[Signal]:
+    """
+    Run all signal readers and return combined results.
+
+    If config is None, loads from the standard locations via
+    nomad.config.load_config(). Each reader receives the full config
+    dict and is responsible for finding its own subsection.
+    """
+    if config is None:
+        from nomad.config import load_config
+        try:
+            config = load_config()
+        except Exception as e:
+            logger.debug(f"Could not load config; using defaults: {e}")
+            config = {}
+
     all_signals: list[Signal] = []
 
     readers = [
-        (read_job_signals, {"hours": hours}),
-        (read_disk_signals, {"hours": min(hours, 12)}),
-        (read_gpu_signals, {"hours": hours}),
-        (read_queue_signals, {"hours": min(hours, 12)}),
-        (read_network_signals, {"hours": min(hours, 12)}),
-        (read_alert_signals, {"hours": hours}),
-        (read_cloud_signals, {"hours": hours}),
+        (read_job_signals,         {"hours": hours}),
+        (read_disk_signals,        {"hours": min(hours, 12)}),
+        (read_gpu_signals,         {"hours": hours}),
+        (read_queue_signals,       {"hours": min(hours, 12)}),
+        (read_network_signals,     {"hours": min(hours, 12)}),
+        (read_alert_signals,       {"hours": hours}),
+        (read_node_health_signals, {"hours": hours}),
+        (read_cloud_signals,       {"hours": hours}),
         (read_workstation_signals, {"hours": min(hours, 12)}),
-        (read_dynamics_signals, {"hours": hours}),
+        (read_dynamics_signals,    {"hours": hours}),
     ]
 
     for reader, kwargs in readers:
         try:
-            sigs = reader(db_path, **kwargs)
+            sigs = reader(db_path, config=config, **kwargs)
             all_signals.extend(sigs)
-        except Exception:
-            pass  # Individual reader failures don't break the engine
+        except Exception as e:
+            logger.debug(f"Signal reader {reader.__name__} failed: {e}")
 
     return all_signals
 

--- a/nomad/insights/signals.py
+++ b/nomad/insights/signals.py
@@ -1245,9 +1245,9 @@ class PerUserSignal:
     rule_type: str = ""
     occurrences: int = 1
     last_seen: str = ""
-    command: Optional[str] = None
-    peak_cpu_percent: Optional[float] = None
-    peak_memory_bytes: Optional[int] = None
+    command: str | None = None
+    peak_cpu_percent: float | None = None
+    peak_memory_bytes: int | None = None
     sustained_for_seconds: int = 0
     context: dict = field(default_factory=dict)
 
@@ -1255,7 +1255,7 @@ class PerUserSignal:
 def read_per_user_signals(
     db_path: str,
     lookback_hours: int = 168,
-    hostname: Optional[str] = None,
+    hostname: str | None = None,
 ) -> list:
     """Pull recent per_user_alert rows; aggregate by (host, user, rule, cmd)."""
     cutoff = (datetime.now() - timedelta(hours=lookback_hours)).strftime(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nomad-hpc"
-version = "1.6.0"
+version = "1.6.1"
 description = "A lightweight HPC monitoring and predictive analytics tool"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,3 +70,42 @@ def db_with_alerts(tmp_path) -> str:
             rows,
         )
     return p
+
+
+# --- node_state fixtures (shared across signal-reader tests) ---------------
+
+@pytest.fixture
+def db_with_node_states(db_path) -> str:
+    """
+    DB with a representative mix of node states for signal/alert tests.
+
+    Node names and cluster come from DEMO_CLUSTER (nomad.demo) so test
+    data is consistent with what `nomad demo` generates. State values
+    are uppercase, matching what scontrol produces on real Slurm
+    clusters (see arachne production DB).
+
+    Mix:
+      node01-node02: healthy (IDLE, MIXED)
+      gpu01:        DOWN+NOT_RESPONDING (critical)
+      gpu02:        DOWN                (critical)
+      node07:       MIXED+DRAIN         (warning)
+    """
+    import sqlite3
+    from datetime import datetime
+
+    now = datetime.utcnow().isoformat()
+    rows = [
+        (now, 'node01', 'IDLE',                '',                  'demo-cluster', 'compute', 1),
+        (now, 'node02', 'MIXED',               '',                  'demo-cluster', 'compute', 1),
+        (now, 'gpu01',  'DOWN+NOT_RESPONDING', 'Not responding',    'demo-cluster', 'gpu',     0),
+        (now, 'gpu02',  'DOWN',                'Unexpected reboot', 'demo-cluster', 'gpu',     0),
+        (now, 'node07', 'MIXED+DRAIN',         'Duplicate jobid',   'demo-cluster', 'highmem', 0),
+    ]
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """INSERT INTO node_state
+               (timestamp, node_name, state, reason, cluster, partitions, is_healthy)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    return db_path

--- a/tests/test_node_state_alerts.py
+++ b/tests/test_node_state_alerts.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Tests for node-state alert dispatch and signal generation.
+
+Node names mirror DEMO_CLUSTER from nomad.demo, and state strings are
+uppercase to match what real Slurm clusters produce via scontrol.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from nomad.collectors.node_state import NodeStateCollector
+from nomad.insights.signals import read_node_health_signals, Severity
+
+
+# ── Signal reader tests ───────────────────────────────────────────────────
+
+def test_node_health_signals_finds_unhealthy(db_with_node_states):
+    sigs = read_node_health_signals(db_with_node_states)
+    titles = {s.title for s in sigs}
+    assert 'node_down' in titles
+    assert 'node_drain' in titles
+
+
+def test_node_health_signals_severity_correct(db_with_node_states):
+    sigs = read_node_health_signals(db_with_node_states)
+    by_node = {s.metrics['node']: s for s in sigs if 'node' in s.metrics}
+
+    # DOWN-family states are critical
+    assert by_node['gpu01'].severity == Severity.CRITICAL  # DOWN+NOT_RESPONDING
+    assert by_node['gpu02'].severity == Severity.CRITICAL  # DOWN
+
+    # DRAIN-family states are warning
+    assert by_node['node07'].severity == Severity.WARNING  # MIXED+DRAIN
+
+
+def test_node_health_signals_empty_on_healthy_cluster(db_path):
+    """No unhealthy nodes = no signals."""
+    import sqlite3
+    from datetime import datetime
+    now = datetime.utcnow().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO node_state (timestamp, node_name, state, reason, "
+            "cluster, partitions, is_healthy) VALUES (?,?,?,?,?,?,?)",
+            (now, 'node01', 'IDLE', '', 'demo-cluster', 'compute', 1),
+        )
+    assert read_node_health_signals(db_path) == []
+
+
+def test_node_health_signals_respects_config(db_with_node_states):
+    """Sites can override which states are critical/warning via config."""
+    config = {
+        'signals': {
+            'node_state': {
+                'critical_states': ['CUSTOM_DOWN'],  # neither DOWN nor DRAIN match
+                'warning_states':  ['DRAIN'],
+                'ignore_states':   ['NOT_RESPONDING'],
+            }
+        }
+    }
+    sigs = read_node_health_signals(db_with_node_states, config=config)
+    surfaced = {s.metrics['node'] for s in sigs if 'node' in s.metrics}
+
+    # gpu01 (DOWN+NOT_RESPONDING) ignored due to NOT_RESPONDING substring
+    assert 'gpu01' not in surfaced
+    # gpu02 (DOWN) doesn't match CUSTOM_DOWN -> warning fallback
+    assert 'gpu02' in surfaced
+    # node07 (MIXED+DRAIN) matches warning list
+    assert 'node07' in surfaced
+
+
+def test_node_health_signals_summary_threshold_disabled(db_with_node_states):
+    """summary_threshold=0 disables the multi-node rollup."""
+    sigs = read_node_health_signals(
+        db_with_node_states,
+        config={'signals': {'node_state': {'summary_threshold': 0}}},
+    )
+    titles = {s.title for s in sigs}
+    assert 'multiple_nodes_unhealthy' not in titles
+
+
+# ── Collector dispatch tests ──────────────────────────────────────────────
+
+def test_collector_dispatches_alerts_for_unhealthy():
+    """The collector should call send_alert for each unhealthy node."""
+    collector = NodeStateCollector({}, ":memory:")
+    records = [
+        {'node_name': 'node01', 'state': 'IDLE',                'is_healthy': 1, 'reason': '',                  'cluster': 'demo-cluster'},
+        {'node_name': 'gpu01',  'state': 'DOWN+NOT_RESPONDING', 'is_healthy': 0, 'reason': 'Not responding',    'cluster': 'demo-cluster'},
+        {'node_name': 'node07', 'state': 'MIXED+DRAIN',         'is_healthy': 0, 'reason': 'Duplicate jobid',   'cluster': 'demo-cluster'},
+    ]
+    with patch('nomad.collectors.node_state.send_alert') as mock_send:
+        collector._dispatch_state_alerts(records)
+        assert mock_send.call_count == 2
+        calls_by_host = {c.kwargs['host']: c.kwargs for c in mock_send.call_args_list}
+        assert calls_by_host['gpu01']['severity'] == 'critical'
+        assert calls_by_host['node07']['severity'] == 'warning'
+
+
+def test_collector_alert_failure_does_not_break_collection():
+    """If dispatcher fails, the collector should keep working."""
+    collector = NodeStateCollector({}, ":memory:")
+    records = [{'node_name': 'gpu01', 'state': 'DOWN', 'is_healthy': 0,
+                'reason': 'test', 'cluster': 'demo-cluster'}]
+    with patch('nomad.collectors.node_state.send_alert', side_effect=RuntimeError("smtp broken")):
+        collector._dispatch_state_alerts(records)  # should not raise
+
+
+def test_collector_classification_uses_defaults_when_unconfigured():
+    """No config = sensible Slurm defaults."""
+    collector = NodeStateCollector({}, ":memory:")
+    # Critical: from arachne production DB
+    assert collector._classify_state('DOWN') == 'critical'
+    assert collector._classify_state('DOWN+NOT_RESPONDING') == 'critical'
+    assert collector._classify_state('NOT_RESPONDING') == 'critical'
+    # Warning: drain family
+    assert collector._classify_state('MIXED+DRAIN') == 'warning'
+    assert collector._classify_state('DRNG') == 'warning'
+    # Unrecognized non-healthy -> warning fallback
+    assert collector._classify_state('IDLE') == 'warning'
+
+
+def test_collector_classification_respects_config():
+    """Sites can override classification via [alerts.node_state]."""
+    config = {
+        'alerts': {
+            'node_state': {
+                'critical_states': ['CUSTOM_DOWN'],
+                'warning_states':  ['CUSTOM_WARN'],
+                'ignore_states':   ['POWERED_DOWN'],
+            }
+        }
+    }
+    collector = NodeStateCollector(config, ":memory:")
+    assert collector._classify_state('CUSTOM_DOWN') == 'critical'
+    assert collector._classify_state('IDLE+CUSTOM_WARN') == 'warning'
+    assert collector._classify_state('POWERED_DOWN') is None
+    # Default 'DOWN' no longer critical because critical_states was replaced
+    assert collector._classify_state('DOWN') == 'warning'  # fallback
+
+
+def test_collector_alerts_disabled_skips_dispatch():
+    """[alerts.node_state] enabled=false silences dispatch."""
+    config = {'alerts': {'node_state': {'enabled': False}}}
+    collector = NodeStateCollector(config, ":memory:")
+    assert collector._alert_config.get('enabled') is False

--- a/tests/test_signals_config.py
+++ b/tests/test_signals_config.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Tests for the config pass-through contract in the signals module."""
+
+import inspect
+import sqlite3
+
+import pytest
+
+from nomad.insights import signals as signals_module
+from nomad.insights.signals import read_all_signals
+
+
+READERS = [
+    'read_job_signals',
+    'read_disk_signals',
+    'read_gpu_signals',
+    'read_queue_signals',
+    'read_network_signals',
+    'read_alert_signals',
+    'read_node_health_signals',
+    'read_cloud_signals',
+    'read_workstation_signals',
+    'read_dynamics_signals',
+]
+
+
+@pytest.mark.parametrize("reader_name", READERS)
+def test_reader_accepts_config_kwarg(reader_name):
+    """Every signal reader must accept a config keyword argument.
+
+    This contract enables read_all_signals to distribute site policy
+    uniformly. Readers that don't yet consume config should still
+    accept and ignore it -- bodies opt in to policy extraction one
+    at a time.
+    """
+    reader = getattr(signals_module, reader_name)
+    sig = inspect.signature(reader)
+    assert 'config' in sig.parameters, (
+        f"{reader_name} must accept a 'config' keyword argument"
+    )
+    assert sig.parameters['config'].default is None, (
+        f"{reader_name}'s config parameter must default to None"
+    )
+
+
+def test_read_all_signals_loads_config_when_none(tmp_path, monkeypatch):
+    """When called without config, read_all_signals should call load_config."""
+    called = {'load_config': False}
+
+    def fake_load_config(path=None):
+        called['load_config'] = True
+        return {'signals': {}}
+
+    monkeypatch.setattr('nomad.config.load_config', fake_load_config)
+
+    db = tmp_path / "empty.db"
+    sqlite3.connect(db).close()
+    read_all_signals(db)
+    assert called['load_config'], "read_all_signals must call load_config when config=None"
+
+
+def test_read_all_signals_uses_passed_config(tmp_path, monkeypatch):
+    """When config is passed explicitly, load_config should NOT be called."""
+    called = {'load_config': False}
+
+    def fake_load_config(path=None):
+        called['load_config'] = True
+        return {}
+
+    monkeypatch.setattr('nomad.config.load_config', fake_load_config)
+
+    db = tmp_path / "empty.db"
+    sqlite3.connect(db).close()
+    read_all_signals(db, config={'signals': {}})
+    assert not called['load_config'], "load_config must not be called when config is passed"

--- a/tests/test_workstation_loading.py
+++ b/tests/test_workstation_loading.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Tests for workstation session loading and scoring in nomad.edu.progress."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from nomad.edu.progress import (
+    _load_user_sessions,
+    _score_sessions,
+    _split_session_fields,
+)
+from nomad.edu.scoring import SessionFingerprint
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+def _make_db(tmp_path):
+    """Build a minimal combined.db schema for loader tests."""
+    db = tmp_path / "combined.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript("""
+        CREATE TABLE workstation_user_snapshot (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME, hostname TEXT, username TEXT,
+            uid INTEGER, session_epoch INTEGER,
+            cpu_usage_usec INTEGER, cpu_user_usec INTEGER,
+            cpu_system_usec INTEGER,
+            memory_current_bytes INTEGER, memory_peak_bytes INTEGER,
+            io_read_bytes INTEGER, io_write_bytes INTEGER,
+            pids_current INTEGER, collector_version TEXT, source TEXT
+        );
+        CREATE TABLE workstation_state (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME, hostname TEXT, department TEXT,
+            status TEXT, memory_total_mb INTEGER, cpu_count INTEGER
+        );
+    """)
+    conn.commit()
+    return db, conn
+
+
+def _insert_session(conn, *, hostname, username, uid, session_epoch,
+                    peak_gb, span_hours, samples=None,
+                    end_offset_hours=1.0):
+    """Insert a synthetic session: first sample + final sample (with peak)."""
+    end = datetime.now() - timedelta(hours=end_offset_hours)
+    start = end - timedelta(hours=span_hours)
+    peak_bytes = int(peak_gb * 1024 * 1024 * 1024)
+    if samples is None:
+        samples = max(2, int(span_hours * 60))
+    for i in range(samples):
+        frac = i / max(1, samples - 1)
+        ts = (start + (end - start) * frac).isoformat()
+        cur_peak = int(peak_bytes * (0.1 + 0.9 * frac))
+        conn.execute("""
+            INSERT INTO workstation_user_snapshot
+              (timestamp, hostname, username, uid, session_epoch,
+               cpu_usage_usec, memory_peak_bytes, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'cgroup_v2')
+        """, (ts, hostname, username, uid, session_epoch,
+              i * 1_000_000, cur_peak))
+
+
+def _insert_host(conn, *, hostname, memory_total_mb, cpu_count):
+    ts = datetime.now().isoformat()
+    conn.execute("""
+        INSERT INTO workstation_state
+          (timestamp, hostname, department, status,
+           memory_total_mb, cpu_count)
+        VALUES (?, ?, 'parish-lab', 'online', ?, ?)
+    """, (ts, hostname, memory_total_mb, cpu_count))
+
+
+# ── Loader: shape & filtering ────────────────────────────────────────
+
+def test_load_returns_session_dicts(tmp_path):
+    """Loader returns one dict per (host, user, session_epoch) with
+    aggregated fields."""
+    db, conn = _make_db(tmp_path)
+    _insert_host(conn, hostname="boyi", memory_total_mb=256_904,
+                 cpu_count=64)
+    _insert_session(conn, hostname="boyi", username="kbui", uid=310395,
+                    session_epoch=1, peak_gb=253.0, span_hours=34.3)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "kbui", days=7)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["hostname"] == "boyi"
+    assert row["username"] == "kbui"
+    assert row["session_epoch"] == 1
+    assert row["peak_memory_bytes"] > 250 * 1024**3
+    assert 33 <= row["span_hours"] <= 35
+    assert row["host_memory_total_mb"] == 256_904
+    assert row["host_cpu_count"] == 64
+    assert row["samples"] >= 2
+
+
+def test_load_filters_uid_under_1000(tmp_path):
+    """System accounts (uid < 1000) must not surface as sessions."""
+    db, conn = _make_db(tmp_path)
+    _insert_host(conn, hostname="aamy", memory_total_mb=30_873, cpu_count=32)
+    _insert_session(conn, hostname="aamy", username="root", uid=0,
+                    session_epoch=1, peak_gb=8.0, span_hours=2.0)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "root", days=7)
+    assert rows == []
+
+
+def test_load_filters_by_username(tmp_path):
+    """Only the requested user's sessions come back."""
+    db, conn = _make_db(tmp_path)
+    _insert_host(conn, hostname="boyi", memory_total_mb=256_904,
+                 cpu_count=64)
+    _insert_session(conn, hostname="boyi", username="kbui", uid=310395,
+                    session_epoch=1, peak_gb=200.0, span_hours=20.0)
+    _insert_session(conn, hostname="boyi", username="someone_else",
+                    uid=99999, session_epoch=2, peak_gb=50.0,
+                    span_hours=4.0)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "kbui", days=7)
+    assert len(rows) == 1
+    assert rows[0]["username"] == "kbui"
+
+
+def test_load_filters_by_window(tmp_path):
+    """Sessions older than the window are not returned."""
+    db, conn = _make_db(tmp_path)
+    _insert_host(conn, hostname="boyi", memory_total_mb=256_904,
+                 cpu_count=64)
+    _insert_session(conn, hostname="boyi", username="kbui", uid=310395,
+                    session_epoch=1, peak_gb=100.0, span_hours=2.0,
+                    end_offset_hours=30 * 24)
+    _insert_session(conn, hostname="boyi", username="kbui", uid=310395,
+                    session_epoch=2, peak_gb=50.0, span_hours=1.0,
+                    end_offset_hours=1)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "kbui", days=7)
+    assert len(rows) == 1
+    assert rows[0]["session_epoch"] == 2
+
+
+def test_load_missing_host_state_yields_null_capacity(tmp_path):
+    """No workstation_state row → host capacity fields are None,
+    not a SQL error. Scoring will mark dimensions inapplicable."""
+    db, conn = _make_db(tmp_path)
+    _insert_session(conn, hostname="ghost_host", username="user1",
+                    uid=1001, session_epoch=1, peak_gb=4.0,
+                    span_hours=1.0)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "user1", days=7)
+    assert len(rows) == 1
+    assert rows[0]["host_memory_total_mb"] is None
+
+
+def test_load_no_db_returns_empty(tmp_path):
+    """Missing DB doesn't raise; returns empty list (parallel to
+    _load_user_jobs)."""
+    rows = _load_user_sessions(
+        str(tmp_path / "does_not_exist.db"), "anyone", days=7
+    )
+    assert rows == []
+
+
+# ── Split helper ─────────────────────────────────────────────────────
+
+def test_split_session_fields():
+    """_split_session_fields separates session and host_state cleanly."""
+    row = {
+        "hostname": "boyi", "username": "kbui", "uid": 310395,
+        "session_epoch": 42, "peak_memory_bytes": 200 * 1024**3,
+        "cpu_usage_usec": 999, "samples": 1200, "span_hours": 12.0,
+        "first_seen": "2026-05-01T00:00:00",
+        "last_seen": "2026-05-01T12:00:00",
+        "host_memory_total_mb": 256_904, "host_cpu_count": 64,
+    }
+    session, host_state = _split_session_fields(row)
+
+    assert session["username"] == "kbui"
+    assert session["peak_memory_bytes"] == 200 * 1024**3
+    assert session["span_hours"] == 12.0
+    assert "host_memory_total_mb" not in session
+
+    assert host_state["memory_total_mb"] == 256_904
+    assert host_state["cpu_count"] == 64
+    assert "peak_memory_bytes" not in host_state
+
+
+# ── End-to-end: load + score ─────────────────────────────────────────
+
+def test_load_and_score_kbui_end_to_end(tmp_path):
+    """Full pipeline: kbui-on-boyi data → SessionFingerprint with both
+    dimensions failing."""
+    db, conn = _make_db(tmp_path)
+    _insert_host(conn, hostname="boyi", memory_total_mb=256_904,
+                 cpu_count=64)
+    _insert_session(conn, hostname="boyi", username="kbui", uid=310395,
+                    session_epoch=1, peak_gb=253.0, span_hours=34.3)
+    conn.commit()
+    conn.close()
+
+    rows = _load_user_sessions(str(db), "kbui", days=7)
+    fps = _score_sessions(rows)
+
+    assert len(fps) == 1
+    fp = fps[0]
+    assert isinstance(fp, SessionFingerprint)
+    assert fp.username == "kbui"
+    assert fp.hostname == "boyi"
+    assert fp.dimensions["memory_pressure"].score < 5
+    assert fp.dimensions["duration_fit"].score == 10
+    assert hasattr(fp, "_last_seen")
+    assert fp._last_seen
+
+
+def test_score_sessions_survives_bad_row():
+    """One unprocessable row doesn't kill the batch."""
+    good_row = {
+        "hostname": "boyi", "username": "kbui", "uid": 310395,
+        "session_epoch": 1, "peak_memory_bytes": 200 * 1024**3,
+        "cpu_usage_usec": 1, "samples": 60, "span_hours": 4.0,
+        "first_seen": "2026-05-01T00:00:00",
+        "last_seen": "2026-05-01T04:00:00",
+        "host_memory_total_mb": 256_904, "host_cpu_count": 64,
+    }
+    bad_row = dict(good_row)
+    bad_row["session_epoch"] = 2
+    bad_row["span_hours"] = "not-a-number"
+
+    fps = _score_sessions([good_row, bad_row])
+    # Good row scores; bad row is logged and skipped
+    assert len(fps) == 1
+    assert fps[0].session_epoch == 1

--- a/tests/test_workstation_scoring.py
+++ b/tests/test_workstation_scoring.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Tests for workstation session scoring in nomad.edu.scoring."""
+
+from __future__ import annotations
+
+import re
+import pytest
+
+from nomad.edu.scoring import (
+    SessionFingerprint,
+    score_duration_fit,
+    score_memory_pressure,
+    score_session,
+    select_cluster_target,
+    SPYDUR_MEMORY_TIERS_MB,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def host_boyi():
+    """boyi: 256 GB host (real Parish lab workstation)."""
+    return {"hostname": "boyi", "memory_total_mb": 256_904, "cpu_count": 64}
+
+
+@pytest.fixture
+def host_thais():
+    """thais: 64 GB host (smaller Parish lab box, the headline example)."""
+    return {"hostname": "thais", "memory_total_mb": 63_642, "cpu_count": 32}
+
+
+def make_session(*, peak_gb: float, span_hours: float, hostname="boyi",
+                 username="user1", session_epoch=1_700_000_000) -> dict:
+    """Build a session dict shaped like a workstation_user_snapshot row
+    aggregated by session_epoch."""
+    return {
+        "username": username,
+        "hostname": hostname,
+        "session_epoch": session_epoch,
+        "peak_memory_bytes": int(peak_gb * 1024 * 1024 * 1024),
+        "span_hours": span_hours,
+        "samples": max(1, int(span_hours * 60)),  # 60s collector cadence
+    }
+
+
+# ── Memory pressure ──────────────────────────────────────────────────
+
+def test_memory_pressure_kbui_critical(host_boyi):
+    """The headline case: kbui on boyi at 98.7% of host RAM."""
+    session = make_session(peak_gb=253.0, span_hours=34.3)
+    score = score_memory_pressure(session, host_boyi)
+    assert score.applicable
+    assert score.score < 5         # critically pressured
+    assert score.level == "Needs Work"
+    # Cgroup peak can equal or slightly exceed host RAM total
+    # because peak_memory_bytes includes cache. Verify pressure
+    # is reported in the saturation zone (>=95%) rather than
+    # asserting an exact percentage.
+    m = re.search(r"\((\d+)%\)", score.detail)
+    assert m is not None, f"no percentage in detail: {score.detail!r}"
+    assert int(m.group(1)) >= 95
+
+
+def test_memory_pressure_comfortable(host_boyi):
+    """5% of a 256 GB host = comfortable."""
+    session = make_session(peak_gb=12.0, span_hours=1.0)
+    score = score_memory_pressure(session, host_boyi)
+    assert score.applicable
+    assert score.score >= 85
+    assert score.level == "Excellent"
+
+
+def test_memory_pressure_moderate(host_boyi):
+    """~50% pressure → middle of the road."""
+    session = make_session(peak_gb=128.0, span_hours=2.0)
+    score = score_memory_pressure(session, host_boyi)
+    assert 45 <= score.score <= 55
+
+
+def test_memory_pressure_missing_host_capacity():
+    """Host capacity unknown → not applicable, not divide-by-zero."""
+    session = make_session(peak_gb=8.0, span_hours=1.0)
+    score = score_memory_pressure(session, {"memory_total_mb": 0})
+    assert not score.applicable
+    assert score.score == 50  # sentinel
+
+
+def test_memory_pressure_missing_peak(host_boyi):
+    """No peak data → not applicable."""
+    session = {"hostname": "boyi", "username": "x", "session_epoch": 1,
+               "peak_memory_bytes": 0, "span_hours": 1.0}
+    score = score_memory_pressure(session, host_boyi)
+    assert not score.applicable
+
+
+# ── Duration fit ─────────────────────────────────────────────────────
+
+def test_duration_fit_short(host_boyi):
+    """30 minute session → perfect score."""
+    session = make_session(peak_gb=4.0, span_hours=0.5)
+    score = score_duration_fit(session, host_boyi)
+    assert score.score == 100
+    assert score.level == "Excellent"
+
+
+def test_duration_fit_4h(host_boyi):
+    """4h falls in 2-6h taper, score around 80."""
+    session = make_session(peak_gb=4.0, span_hours=4.0)
+    score = score_duration_fit(session, host_boyi)
+    assert 75 <= score.score <= 85
+
+
+def test_duration_fit_12h(host_boyi):
+    """12h falls in 6-18h taper, score around 45."""
+    session = make_session(peak_gb=4.0, span_hours=12.0)
+    score = score_duration_fit(session, host_boyi)
+    assert 40 <= score.score <= 50
+
+
+def test_duration_fit_kbui_floor(host_boyi):
+    """34h hits the >=18h floor."""
+    session = make_session(peak_gb=4.0, span_hours=34.3)
+    score = score_duration_fit(session, host_boyi)
+    assert score.score == 10
+    assert score.level == "Needs Work"
+
+
+def test_duration_fit_missing(host_boyi):
+    """No span data → not applicable."""
+    session = {"hostname": "boyi", "username": "x", "session_epoch": 1,
+               "peak_memory_bytes": 1024, "span_hours": None}
+    score = score_duration_fit(session, host_boyi)
+    assert not score.applicable
+
+
+# ── Composite scoring ────────────────────────────────────────────────
+
+def test_score_session_kbui_both_critical(host_boyi):
+    """The headline case fingerprint: both dimensions critical."""
+    session = make_session(peak_gb=253.0, span_hours=34.3, username="kbui")
+    fp = score_session(session, host_boyi)
+    assert isinstance(fp, SessionFingerprint)
+    assert fp.username == "kbui"
+    assert fp.hostname == "boyi"
+    assert set(fp.dimensions) == {"memory_pressure", "duration_fit"}
+    assert all(d.score < 20 for d in fp.dimensions.values())
+    assert fp.overall < 20
+    assert len(fp.needs_work) == 2
+
+
+def test_score_session_memory_only(host_thais):
+    """High memory, short duration: only memory dimension trips."""
+    session = make_session(peak_gb=60.0, span_hours=0.5, hostname="thais")
+    fp = score_session(session, host_thais)
+    assert fp.dimensions["memory_pressure"].score < 20
+    assert fp.dimensions["duration_fit"].score == 100
+
+
+def test_score_session_duration_only(host_boyi):
+    """Long duration, low memory: only duration dimension trips."""
+    session = make_session(peak_gb=8.0, span_hours=20.0)
+    fp = score_session(session, host_boyi)
+    assert fp.dimensions["memory_pressure"].score >= 85
+    assert fp.dimensions["duration_fit"].score == 10
+
+
+def test_score_session_benign(host_boyi):
+    """Short, low-memory session: everything good."""
+    session = make_session(peak_gb=4.0, span_hours=1.0)
+    fp = score_session(session, host_boyi)
+    assert fp.overall >= 85
+    assert fp.needs_work == []
+
+
+# ── Cluster target selection ─────────────────────────────────────────
+
+def test_select_target_kbui():
+    """boyi (256 GB) with kbui's 253 GB peak: 384 GB tier is too close
+    (1.5× host), bump to 768 GB tier (3× host)."""
+    result = select_cluster_target(peak_mb=253 * 1024, host_mb=256_904)
+    assert result is not None
+    target_mb, ratio = result
+    assert target_mb == 768_000
+    assert 2.9 <= ratio <= 3.1
+
+
+def test_select_target_thais():
+    """thais (64 GB) with a 60 GB peak: 384 GB tier already gives 6×."""
+    result = select_cluster_target(peak_mb=60 * 1024, host_mb=63_642)
+    assert result is not None
+    target_mb, ratio = result
+    assert target_mb == 384_000
+    assert 5.5 <= ratio <= 6.5
+
+
+def test_select_target_extreme():
+    """A 1 TB peak: even the 1.5 TB tier is required."""
+    result = select_cluster_target(peak_mb=1_000_000, host_mb=63_642)
+    assert result is not None
+    target_mb, _ = result
+    assert target_mb == 1_536_000
+
+
+def test_select_target_unreachable():
+    """A peak that exceeds even the largest tier: None."""
+    result = select_cluster_target(peak_mb=2_000_000, host_mb=63_642)
+    assert result is None
+
+
+def test_select_target_invalid_inputs():
+    """Zero or negative inputs return None rather than crashing."""
+    assert select_cluster_target(peak_mb=0, host_mb=64_000) is None
+    assert select_cluster_target(peak_mb=10_000, host_mb=0) is None
+
+
+def test_select_target_tiers_are_sorted():
+    """Defensive: out-of-order tiers shouldn't break the algorithm."""
+    result = select_cluster_target(
+        peak_mb=253 * 1024, host_mb=256_904,
+        tiers=(1_536_000, 384_000, 768_000),  # deliberately scrambled
+    )
+    assert result == (768_000, 768_000 / 256_904)


### PR DESCRIPTION
## Summary

Closes the gap where node failures weren't surfaced in the daily brief
or dispatched as alerts. Establishes the config pass-through pattern
for all future signal readers.

## What was broken

`node_state` collector wrote samples to the DB but never dispatched
alerts. `nomad insights brief` had no signal reader for node health.
End result: when nodes went DOWN on production clusters, NØMAD knew
about it but the morning email said nothing.

Discovered when two GPU nodes on arachne went DOWN+NOT_RESPONDING
overnight and the 08:01 digest the next morning made no mention.

## What this does

1. Hooks `node_state` collector into `AlertDispatcher` for realtime alerts
2. Adds `read_node_health_signals` so the digest surfaces node issues
3. Both paths are site-configurable via `[alerts.node_state]` and `[signals.node_state]`
4. Every signal reader now accepts `config=None` (uniform contract)
5. New `db_with_node_states` fixture in conftest using DEMO_CLUSTER names
6. 22 new tests, all 557 in the suite still pass

## Architecture: two namespaces, two purposes

- `[signals.*]` controls what shows in the brief / dashboard
- `[alerts.thresholds.*]` and `[alerts.node_state]` control dispatch

Sites can tune them independently or together.

## Follow-ups (filed as issues)

- Extract policy from remaining signal readers (job, queue, network,
  workstation, dynamics) using the same pattern
- Fix `nomad.toml.example` to be valid TOML (v1.6.2 — priority due to
  upcoming tutorial)
- Normalize demo node states to uppercase for production parity

## Testing

$ pytest tests/ -q
557 passed in 23.84s
