### PR TITLE
fix(config): make nomad.toml.example valid TOML and complete

### DIFF
--- a/nomad.toml.example
+++ b/nomad.toml.example
@@ -26,26 +26,21 @@ pid_file = "/var/run/nomade/nomade.pid"
 # ============================================
 
 [collectors]
-# Enable/disable individual collectors
-disk = true
-slurm = true
-nodes = true
-licenses = true
-jobs = true      # Requires SLURM prolog/epilog hooks
-network = false  # Optional network monitoring
+# Enable/disable specific collectors. Listed names map to the
+# [collectors.<name>] subtables below. Available collectors:
+#   disk, slurm, nodes, licenses, jobs, gpu, nfs,
+#   workstation, storage, network_perf, node_state
+enabled = ["disk", "slurm", "nodes", "licenses", "jobs"]
 
-# Collection intervals (seconds)
-disk_interval = 300      # Every 5 minutes
-slurm_interval = 60      # Every minute
-nodes_interval = 120     # Every 2 minutes
-licenses_interval = 300  # Every 5 minutes
-network_interval = 60    # Every minute
+# Default collection interval in seconds. Each [collectors.<name>]
+# subtable can override this with its own `interval = N`.
 
 # ============================================
 # DISK COLLECTOR
 # ============================================
 
 [collectors.disk]
+interval = 300  # Every 5 minutes
 # Filesystems to monitor
 filesystems = [
     "/",
@@ -77,6 +72,7 @@ scan_for_large_files = false  # Can be slow on large filesystems
 # ============================================
 
 [collectors.slurm]
+interval = 60   # Every minute
 # Path to SLURM commands (if not in PATH)
 # slurm_bin_path = "/usr/bin"
 
@@ -97,6 +93,7 @@ check_zombies = true
 # ============================================
 
 [collectors.nodes]
+interval = 120  # Every 2 minutes
 # How to check node health
 # Options: "slurm" (sinfo only), "ssh" (SSH to each node)
 health_check_method = "slurm"
@@ -125,6 +122,7 @@ check_services = ["slurmd", "munge"]
 # ============================================
 
 [collectors.licenses]
+interval = 300  # Every 5 minutes
 # License servers to monitor
 
 [[collectors.licenses.servers]]
@@ -478,6 +476,76 @@ source = "wire-src"
 dest = "10.0.0.1"        # Private IP on direct cable
 path_type = "direct"
 user = "root"
+
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# [database] — Where NOMAD stores its operational data.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[database]
+# SQLite database filename (relative to [general] data_dir) or absolute path.
+# Default is "nomad.db" inside data_dir.
+#
+# Examples:
+#   path = "nomad.db"               # -> data_dir/nomad.db (default)
+#   path = "mydb.sqlite"            # -> data_dir/mydb.sqlite
+#   path = "/var/lib/nomad/prod.db" # absolute, used as-is
+path = "nomad.db"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# [ml] — Machine learning predictions and continuous learning.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[ml]
+# Enable ML-based job failure prediction and resource forecasting.
+enabled = true
+
+# Number of training epochs for the ensemble model.
+epochs = 100
+
+# Where trained models live, relative to [general] data_dir or absolute path.
+models_dir = "models"
+
+[ml.learning]
+# Continuous learning strategy:
+#   "count" -- retrain after N new jobs
+#   "time"  -- retrain every N hours
+#   "drift" -- retrain when data drift is detected
+strategy = "count"
+
+# Retrain after this many new jobs (for "count" strategy).
+job_threshold = 100
+
+# Retrain every N hours (for "time" strategy).
+interval_hours = 6
+
+# Minimum jobs required before training can begin.
+min_jobs = 50
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# [slurm] — Optional integration with SLURM's prolog/epilog hooks for
+# real-time job scoring. Only relevant if you want NOMAD to evaluate
+# jobs as they enter the queue.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[slurm]
+# Path to SLURM binaries if not in $PATH. Leave commented to use $PATH.
+# bin_path = "/usr/bin"
+
+[slurm.prolog]
+# Score jobs in real time as they're submitted via slurmctld prolog hook.
+# Requires installing the NOMAD prolog script into SLURM's prolog config.
+enabled = false
+
+# Risk threshold (0.0 - 1.0): jobs scoring above this are logged for review.
+risk_threshold = 0.7
+
+# Where to log high-risk job submissions.
+log_file = "/var/log/nomad/high_risk_jobs.log"
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # [signals.*] — Site policy for the insight engine's signal generators.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nomad-hpc"
-version = "1.6.1"
+version = "1.6.2"
 description = "A lightweight HPC monitoring and predictive analytics tool"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/tests/test_toml_example_valid.py
+++ b/tests/test_toml_example_valid.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Validate that the example and default TOML configs actually parse.
+
+These files are what users copy as a starting point; if either is
+malformed, the user's first NOMAD experience is a stack trace. This
+test locks in the invariant that they parse cleanly.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11),
+                    reason="tomllib is stdlib only on 3.11+")
+def test_nomad_toml_example_parses():
+    """nomad.toml.example must be valid TOML."""
+    import tomllib
+
+    example = REPO_ROOT / "nomad.toml.example"
+    assert example.exists(), f"missing: {example}"
+
+    with example.open("rb") as f:
+        config = tomllib.load(f)
+
+    # Sanity: expected top-level sections present
+    assert "collectors" in config, "[collectors] section missing"
+    assert "alerts" in config, "[alerts] section missing"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11),
+                    reason="tomllib is stdlib only on 3.11+")
+def test_default_toml_parses():
+    """nomad/config/default.toml must also be valid TOML."""
+    import tomllib
+
+    default = REPO_ROOT / "nomad" / "config" / "default.toml"
+    assert default.exists(), f"missing: {default}"
+
+    with default.open("rb") as f:
+        config = tomllib.load(f)
+
+    assert isinstance(config, dict)
+    assert len(config) > 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11),
+                    reason="tomllib is stdlib only on 3.11+")
+def test_example_matches_default_top_level_sections():
+    """The example and default should share their top-level section names.
+
+    If one of them gains a section the other lacks, that's a documentation
+    drift bug -- users following the example wouldn't discover the new
+    section, or vice versa.
+    """
+    import tomllib
+
+    with (REPO_ROOT / "nomad.toml.example").open("rb") as f:
+        example_cfg = tomllib.load(f)
+    with (REPO_ROOT / "nomad" / "config" / "default.toml").open("rb") as f:
+        default_cfg = tomllib.load(f)
+
+    example_sections = set(example_cfg.keys())
+    default_sections = set(default_cfg.keys())
+
+    # Both files should describe the same overall config surface.
+    # Missing sections in either direction signal drift.
+    only_in_example = example_sections - default_sections
+    only_in_default = default_sections - example_sections
+
+    # Allow some sections only in example (extra documentation is OK),
+    # but flag sections in default not documented in example.
+    assert not only_in_default, (
+        f"Sections present in default.toml but not nomad.toml.example: "
+        f"{only_in_default}. Update nomad.toml.example."
+    )


### PR DESCRIPTION
## What this fixes

`nomad.toml.example` has been unparseable since someone added `[collectors.<name>]` subtables alongside pre-existing top-level scalar toggles. Anyone copying the file as a starting point hit `TOMLDecodeError` on first run.

Five collisions resolved by adopting `default.toml`'s convention. Also adds three sections (`[database]`, `[ml]`, `[slurm]`) that were in `default.toml` but missing from the example.

## Why now

I'm giving a NØMAD tutorial soon. Workshop attendees copying the example file as their starting point would hit the parse error immediately.

## Test coverage

New `tests/test_toml_example_valid.py` with three guards:
- `nomad.toml.example` parses
- `default.toml` parses
- top-level sections of both stay in sync (no drift)

The third caught real drift on first run — three sections missing from the example. The test paid for itself immediately.

## Impact

No live code reads the old toggle scalars (`disk = true` etc.) — only `.bak` backup files reference them. The shape NØMAD actually uses, in `default.toml`, has been consistent all along. This brings `.example` into line with reality.

560 tests pass. Discovered while validating PR #2 additions.