### PR TITLE
fix(config): nomad.toml.example documents the schema the dispatcher reads

### DIFF
--- a/nomad.toml.example
+++ b/nomad.toml.example
@@ -239,36 +239,39 @@ monitor_exports = true
 # ============================================
 
 [alerts]
-# Alert dispatch configuration
+# Alert dispatch configuration.
+#
+# Only signals at or above min_severity are dispatched. Cooldown
+# prevents the same alert from being sent repeatedly.
+min_severity = "warning"     # info | warning | critical
+cooldown_minutes = 15
 
-# Email
-email_enabled = true
-email_to = ["hpc-admin@example.edu"]
-email_cc = []
-email_from = "nomade@cluster.example.edu"
-smtp_host = "smtp.example.edu"
-smtp_port = 25
-smtp_use_tls = false
+# ─── Email dispatch ──────────────────────────────────────────────
+# IMPORTANT: the values below are placeholders. To enable email,
+# (1) replace smtp_server / from / recipients with values for your
+# institution, then (2) set enabled = true.
+[alerts.email]
+enabled = false
+smtp_server = "smtp.your-institution.edu"
+smtp_port = 587
+use_tls = true
 # smtp_username = ""
 # smtp_password = ""
+from_address = "nomad@your-institution.edu"
+recipients = ["hpc-admin@your-institution.edu"]
 
-# Slack
-slack_enabled = false
-slack_webhook_url = ""
-slack_channel = "#hpc-alerts"
+# ─── Slack dispatch ──────────────────────────────────────────────
+[alerts.slack]
+enabled = false
+webhook_url = ""             # paste your Slack incoming webhook URL
+channel = "#hpc-alerts"
+username = "NOMAD"
 
-# Generic webhook
-webhook_enabled = false
-webhook_url = ""
-webhook_headers = { Authorization = "Bearer TOKEN" }
-
-# Alert behavior
-# Minimum seconds between repeated alerts for the same issue
-default_cooldown = 3600
-
-# Aggregate multiple alerts into a single digest
-digest_enabled = false
-digest_interval = 3600
+# ─── Generic webhook ─────────────────────────────────────────────
+[alerts.webhook]
+enabled = false
+url = ""
+# auth_token = ""             # passed as Authorization: Bearer <token>
 
 # ============================================
 # ALERT THRESHOLDS
@@ -363,7 +366,9 @@ coverage_warning_percent = 90
 [dashboard]
 # Web dashboard settings
 enabled = true
-host = "0.0.0.0"
+# Bind to loopback by default. Set to "0.0.0.0" to expose to other
+# hosts on the network (e.g. for centralized monitoring servers).
+host = "127.0.0.1"
 port = 8080
 
 # Authentication (optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nomad-hpc"
-version = "1.6.2"
+version = "1.6.3"
 description = "A lightweight HPC monitoring and predictive analytics tool"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/tests/test_toml_example_valid.py
+++ b/tests/test_toml_example_valid.py
@@ -79,3 +79,63 @@ def test_example_matches_default_top_level_sections():
         f"Sections present in default.toml but not nomad.toml.example: "
         f"{only_in_default}. Update nomad.toml.example."
     )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11),
+                    reason="tomllib is stdlib only on 3.11+")
+def test_alerts_subtables_match_dispatcher_schema():
+    """The dispatcher reads config['alerts']['email'/'slack'/'webhook'].
+
+    The example must document those subtables, not the legacy flat keys
+    (email_enabled = true under [alerts]) that the dispatcher never reads.
+    Defaults must be enabled=false so admins opt in deliberately rather
+    than getting silent SMTP failures against placeholder values.
+    """
+    import tomllib
+
+    with (REPO_ROOT / "nomad.toml.example").open("rb") as f:
+        cfg = tomllib.load(f)
+
+    alerts = cfg.get("alerts", {})
+
+    # Subtables present
+    for backend in ("email", "slack", "webhook"):
+        assert backend in alerts, f"missing [alerts.{backend}] subtable"
+        assert "enabled" in alerts[backend], (
+            f"[alerts.{backend}] missing 'enabled' key"
+        )
+
+    # Legacy flat keys absent (dispatcher would silently ignore them)
+    for legacy in ("email_enabled", "slack_enabled", "webhook_enabled"):
+        assert legacy not in alerts, (
+            f"[alerts] has legacy flat key '{legacy}' that the dispatcher "
+            f"won't read; use [alerts.{legacy.split('_')[0]}] instead."
+        )
+
+    # Sensible defaults: nothing dispatching by default
+    for backend in ("email", "slack", "webhook"):
+        assert alerts[backend]["enabled"] is False, (
+            f"[alerts.{backend}] should default enabled=false to prevent "
+            f"silent failures on first install with placeholder values."
+        )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11),
+                    reason="tomllib is stdlib only on 3.11+")
+def test_dashboard_binds_to_loopback_by_default():
+    """The example must not bind the dashboard to all interfaces by default.
+
+    0.0.0.0 exposes the dashboard to anyone on the network. Sites that
+    want centralized monitoring (like mingus) can opt in by setting
+    host = "0.0.0.0", but new installs should be safe by default.
+    """
+    import tomllib
+
+    with (REPO_ROOT / "nomad.toml.example").open("rb") as f:
+        cfg = tomllib.load(f)
+
+    host = cfg.get("dashboard", {}).get("host", "0.0.0.0")
+    assert host in ("127.0.0.1", "localhost", "::1"), (
+        f"dashboard.host = '{host}' exposes the dashboard to all network "
+        f"interfaces. Default to a loopback address; document opt-in."
+    )


### PR DESCRIPTION
## Summary

`nomad.toml.example` documented a schema the AlertDispatcher doesn't read.

The dispatcher (`nomad/alerts/dispatcher.py` line 60-90) reads subtables `[alerts.email]`, `[alerts.slack]`, `[alerts.webhook]`. The example shipped flat keys (`email_enabled = true`) under `[alerts]`. Admins copying the example file got config that did nothing.

## Why now

Workshop tutorial coming up. Attendees copying the example file would get a working-looking config that's actually a no-op. Better to fix this before they see it.

## What changes

- `[alerts]` block restructured to use subtables
- All three dispatch backends (email, slack, webhook) default to `enabled = false`
- Placeholder values changed from `smtp.example.edu` to `smtp.your-institution.edu` so they're visibly placeholders
- `dashboard.host` defaults to `127.0.0.1` instead of `0.0.0.0` — sites doing centralized monitoring opt in deliberately
- Two new regression tests guard the schema and the loopback default

## What doesn't change

The dispatcher code. It's been correct all along. Only the documentation was wrong.

## Discovered during v1.6.2 rollout

On 2026-05-18, all three daemon hosts (arachne, spydur, spiderweb) had `[alerts.email] enabled = true` with `smtp.example.com` SMTP placeholders. The placeholder SMTP server doesn't resolve, so dispatch was a silent no-op. Worth a follow-up to remind operators to either configure real SMTP or set `enabled = false` on those hosts.

## Testing

562 tests pass (560 from v1.6.2 + 2 new for this PR).