### PR TITLE
fix(alerts): nomad test-alerts must actually test dispatch end-to-end

### DIFF
--- a/nomad/cli.py
+++ b/nomad/cli.py
@@ -1479,73 +1479,107 @@ def report(ctx, db, output):
 
 
 @cli.command('test-alerts')
-@click.option('--email', is_flag=True, help='Test email backend')
-@click.option('--slack', is_flag=True, help='Test Slack backend')
-@click.option('--webhook', is_flag=True, help='Test webhook backend')
+@click.option('--email', is_flag=True, help='Test only the email backend')
+@click.option('--slack', is_flag=True, help='Test only the Slack backend')
+@click.option('--webhook', is_flag=True, help='Test only the webhook backend')
 @click.pass_context
 def test_alerts(ctx, email, slack, webhook):
-    """Test alert notification backends.
-    
+    """Test configured alert notification backends end-to-end.
+
+    Runs a connection check on each configured backend, then dispatches
+    a synthetic warning-severity alert through the full dispatch path
+    (filtering, cooldown, send). Use this to confirm that real alerts
+    will reach their destinations.
+
     Examples:
-        nomad test-alerts --email     # Test email
-        nomad test-alerts --slack     # Test Slack
-        nomad test-alerts             # Test all configured backends
+        nomad test-alerts                  # Test all configured backends
+        nomad test-alerts --email          # Test only email
+        nomad test-alerts --email --slack  # Test email and Slack
     """
     from nomad.alerts import AlertDispatcher
 
     config = ctx.obj.get('config', {})
-
-    # Build test config if flags provided
-    if email or slack or webhook:
-        if email:
-            click.echo("Testing email backend...")
-            # Would need config from file
-        if slack:
-            click.echo("Testing Slack backend...")
-        if webhook:
-            click.echo("Testing webhook backend...")
-
-    # Test with actual config
     dispatcher = AlertDispatcher(config)
 
     if not dispatcher.backends:
         click.echo(click.style("No alert backends configured.", fg="yellow"))
-        click.echo("Add configuration to nomad.toml:")
-        click.echo("""
-[alerts.email]
-enabled = true
-smtp_server = "smtp.example.com"
-recipients = ["admin@example.com"]
-
-[alerts.slack]
-enabled = true
-webhook_url = "https://hooks.slack.com/..."
-""")
+        click.echo("Add configuration to nomad.toml. For example:")
+        click.echo("")
+        click.echo('[alerts.email]')
+        click.echo('enabled = true')
+        click.echo('smtp_server = "smtp.your-institution.edu"   # or "127.0.0.1" for local sendmail')
+        click.echo('smtp_port = 587')
+        click.echo('use_tls = true')
+        click.echo('from_address = "nomad@your-institution.edu"')
+        click.echo('recipients = ["admin@your-institution.edu"]')
+        click.echo("")
+        click.echo('[alerts.slack]')
+        click.echo('enabled = true')
+        click.echo('webhook_url = "https://hooks.slack.com/services/..."')
+        click.echo("")
+        click.echo('[alerts.webhook]')
+        click.echo('enabled = true')
+        click.echo('url = "https://your-monitoring.example.com/webhook"')
         return
 
-    click.echo(f"Testing {len(dispatcher.backends)} backend(s)...")
-    results = dispatcher.test_backends()
+    flag_to_class = {
+        'EmailBackend':   email,
+        'SlackBackend':   slack,
+        'WebhookBackend': webhook,
+    }
+    selected_classes = {cls for cls, flag in flag_to_class.items() if flag}
 
+    if selected_classes:
+        filtered = [b for b in dispatcher.backends
+                    if b.__class__.__name__ in selected_classes]
+        if not filtered:
+            missing = ", ".join(sorted(selected_classes))
+            click.echo(click.style(
+                f"Requested backend(s) not configured: {missing}",
+                fg="yellow",
+            ))
+            configured = ", ".join(
+                b.__class__.__name__ for b in dispatcher.backends
+            )
+            click.echo(f"Configured backends: {configured}")
+            return
+        dispatcher.backends = filtered
+
+    click.echo(f"Testing {len(dispatcher.backends)} backend(s)...")
+
+    results = dispatcher.test_backends()
     for backend, success in results.items():
         if success:
             click.echo(click.style(f"  {backend}: OK", fg="green"))
         else:
             click.echo(click.style(f"  {backend}: FAILED", fg="red"))
 
-    # Send test alert
-    click.echo("\nSending test alert...")
+    click.echo("")
+    click.echo("Sending test alert (severity=warning)...")
     send_results = dispatcher.dispatch({
-        'severity': 'info',
+        'severity': 'warning',
         'source': 'test',
-        'message': 'This is a test alert from NOMAD',
-        'host': 'cli-test'
+        'message': ('NOMAD test alert (nomad test-alerts). '
+                    'If you received this, real alerts will reach you.'),
+        'host': 'cli-test',
     })
+
+    if not send_results:
+        click.echo(click.style(
+            "  No backends dispatched. Possible causes:", fg="yellow",
+        ))
+        click.echo("    - Alert filtered by [alerts] min_severity")
+        click.echo("    - Alert in cooldown window (cooldown_minutes)")
+        click.echo("    - No backends matched the selected flags")
+        return
 
     for backend, success in send_results.items():
         if success:
             click.echo(click.style(f"  {backend}: Sent", fg="green"))
         else:
-            click.echo(click.style(f"  {backend}: Failed", fg="red"))
+            click.echo(click.style(
+                f"  {backend}: Failed (see log for details)", fg="red",
+            ))
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nomad-hpc"
-version = "1.6.3"
+version = "1.6.4"
 description = "A lightweight HPC monitoring and predictive analytics tool"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/tests/test_cli_test_alerts.py
+++ b/tests/test_cli_test_alerts.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 João Tonini
+"""Regression tests for the `nomad test-alerts` CLI subcommand.
+
+Guards against three real bugs discovered during v1.6.4 SMTP wiring
+on arachne:
+
+  1. test-alerts shipped severity='info' against default
+     min_severity='warning'. dispatch() silently filtered it,
+     returned {}, the CLI iterated zero items and produced
+     no Sent/Failed output. Operators couldn't tell the difference
+     between success and silent drop.
+
+  2. --email/--slack/--webhook flags were documented in --help
+     but had no effect.
+
+  3. Empty dispatch result produced no CLI output, leaving
+     operators unable to distinguish success from silent drop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from nomad.cli import cli
+
+
+def _make_mock_backend(class_name, test_returns=True, send_returns=True):
+    """Mock backend that mimics nomad.alerts.backends.NotificationBackend."""
+    backend = MagicMock()
+    backend.__class__.__name__ = class_name
+    backend.test.return_value = test_returns
+    backend.send.return_value = send_returns
+    backend.enabled = True
+    return backend
+
+
+@pytest.fixture
+def mock_email_backend():
+    return _make_mock_backend("EmailBackend")
+
+
+@pytest.fixture
+def mock_slack_backend():
+    return _make_mock_backend("SlackBackend")
+
+
+@pytest.fixture
+def make_dispatcher():
+    """Returns a function that produces a mocked AlertDispatcher.
+
+    The mock mimics the real dispatcher's behavior: test_backends() calls
+    .test() on each backend, dispatch() respects severity filter and
+    calls .send() on each backend whose alert passed the filter.
+    """
+    def _make(backends):
+        dispatcher = MagicMock()
+        dispatcher.backends = list(backends)
+
+        def test_backends():
+            return {b.__class__.__name__: b.test()
+                    for b in dispatcher.backends}
+        dispatcher.test_backends = test_backends
+
+        def dispatch(alert):
+            severity_order = {'info': 0, 'warning': 1, 'critical': 2}
+            min_sev = severity_order.get('warning', 1)
+            alert_sev = severity_order.get(alert.get('severity', 'info'), 0)
+            if alert_sev < min_sev:
+                return {}
+            return {b.__class__.__name__: b.send(alert)
+                    for b in dispatcher.backends}
+        dispatcher.dispatch = dispatch
+
+        return dispatcher
+    return _make
+
+
+# Core regression: test-alerts must call backend.send()
+
+def test_test_alerts_calls_send_not_just_test(mock_email_backend, make_dispatcher):
+    """Regression: test-alerts must exercise the dispatch+send path,
+    not just the connection check via test_backends().
+
+    Was failing because severity='info' got filtered by default
+    min_severity='warning', dispatch returned {}, send was never called.
+    """
+    dispatcher = make_dispatcher([mock_email_backend])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_email_backend.test.called, "backend.test() must run"
+    assert mock_email_backend.send.called, (
+        "backend.send() must run -- this is the whole point of test-alerts. "
+        f"Output was:\n{result.output}"
+    )
+
+
+def test_test_alerts_uses_warning_severity(mock_email_backend, make_dispatcher):
+    """The synthetic alert must use severity='warning' so it passes
+    typical min_severity filters and the dispatch path actually runs.
+    """
+    dispatcher = make_dispatcher([mock_email_backend])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts"])
+
+    assert result.exit_code == 0, result.output
+
+    call_args = mock_email_backend.send.call_args
+    assert call_args is not None, "send() was not called"
+    alert = call_args[0][0]
+    assert alert["severity"] == "warning", (
+        f"test-alerts must ship severity='warning', got {alert['severity']!r}. "
+        "Lower severities get silently filtered by default min_severity."
+    )
+
+
+def test_test_alerts_reports_sent_in_output(mock_email_backend, make_dispatcher):
+    """When send() succeeds, output must contain 'Sent' for that backend."""
+    dispatcher = make_dispatcher([mock_email_backend])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts"])
+
+    assert result.exit_code == 0
+    assert "Sent" in result.output, (
+        f"Expected 'Sent' in output, got:\n{result.output}"
+    )
+    assert "EmailBackend" in result.output
+
+
+# Flag filtering: --email, --slack, --webhook must actually filter
+
+def test_email_flag_tests_only_email_backend(
+    mock_email_backend, mock_slack_backend, make_dispatcher,
+):
+    """--email should test only the email backend, not slack."""
+    dispatcher = make_dispatcher([mock_email_backend, mock_slack_backend])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts", "--email"])
+
+    assert result.exit_code == 0
+    assert mock_email_backend.send.called, "Email backend should be tested"
+    assert not mock_slack_backend.send.called, (
+        "Slack backend should be skipped when --email is passed alone"
+    )
+
+
+def test_multiple_flags_tests_multiple_backends(
+    mock_email_backend, mock_slack_backend, make_dispatcher,
+):
+    """--email --slack should test both backends."""
+    dispatcher = make_dispatcher([mock_email_backend, mock_slack_backend])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts", "--email", "--slack"])
+
+    assert result.exit_code == 0
+    assert mock_email_backend.send.called
+    assert mock_slack_backend.send.called
+
+
+def test_unselected_flag_reports_missing_backend(make_dispatcher):
+    """--slack when slack isn't configured should report cleanly,
+    not crash and not silently test nothing.
+    """
+    email_only = _make_mock_backend("EmailBackend")
+    dispatcher = make_dispatcher([email_only])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts", "--slack"])
+
+    assert result.exit_code == 0
+    assert "SlackBackend" in result.output
+    assert "not configured" in result.output.lower()
+    assert not email_only.send.called, (
+        "Should not test email when --slack was explicitly requested"
+    )
+
+
+# Empty dispatch: never be silent
+
+def test_empty_dispatch_explains_silence(mock_email_backend, make_dispatcher):
+    """When dispatch() returns {} (filtered, cooldown, etc.), the CLI
+    must say so explicitly rather than producing zero output.
+    """
+    dispatcher = make_dispatcher([mock_email_backend])
+    dispatcher.dispatch = lambda alert: {}
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts"])
+
+    assert result.exit_code == 0
+    output_lower = result.output.lower()
+    assert any(token in output_lower for token in (
+        "filtered", "cooldown", "no backends dispatched", "min_severity",
+    )), (
+        f"Empty dispatch must produce visible explanation. Output was:\n"
+        f"{result.output}"
+    )
+
+
+# No-backends help text: must use safe placeholders
+
+def test_no_backends_uses_safe_placeholder_smtp(make_dispatcher):
+    """When no backends are configured, the example shown must not
+    use realistic-looking placeholders that admins might paste verbatim.
+    Same v1.6.3 fix applied to the CLI help text.
+    """
+    dispatcher = make_dispatcher([])
+
+    with patch("nomad.alerts.AlertDispatcher", return_value=dispatcher):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test-alerts"])
+
+    assert result.exit_code == 0
+    assert "smtp.example.com" not in result.output, (
+        "Help text must not show smtp.example.com as a placeholder -- "
+        "admins paste it verbatim and silent failures result."
+    )
+    assert "your-institution" in result.output or "127.0.0.1" in result.output


### PR DESCRIPTION
## Summary

`nomad test-alerts` has three bugs that combine to make the command silently fail without indication. Discovered while wiring SMTP on arachne today: direct `EmailBackend.send()` produced a real email, but `nomad test-alerts` trailed off at 'Sending test alert...' with no further output. The dispatch path was being filtered by severity before reaching the send code.

## Three bugs fixed

1. **Severity**: shipped `severity='info'` against default `min_severity='warning'`. `dispatch()` silently filtered the alert and returned `{}`. Now ships `'warning'`.

2. **Flag filtering**: `--email / --slack / --webhook` were documented but did nothing. Now implemented as backend filters that combine when multiple flags are passed.

3. **Empty dispatch silence**: When `dispatch()` returned `{}` for any reason, the CLI's for-loop iterated zero items, producing no output. Now prints an explicit explanation listing the three possible causes.

## Also fixed

The no-backends-configured help text previously showed `smtp_server = "smtp.example.com"` — same misleading default v1.6.3 corrected in `nomad.toml.example`. Updated to use safe `your-institution.edu` placeholders plus a hint about `127.0.0.1:25` for sites with existing MTAs.

## Test coverage

`tests/test_cli_test_alerts.py` (8 tests) locks in the invariants. The most important regression: `test_test_alerts_calls_send_not_just_test` asserts that `backend.send()` is actually invoked, preventing the original silent-drop bug from coming back.

## Validation after merge

After updating arachne in place, `nomad test-alerts` produces a real email and prints `EmailBackend: Sent`. No more silent failures.

570 tests pass (562 + 8 new).