### PR TITLE
fix(alerts): nomad collect must initialize the alert dispatcher

### DIFF
--- a/nomad/cli.py
+++ b/nomad/cli.py
@@ -167,6 +167,37 @@ def collect(ctx: click.Context, collector: tuple, once: bool, interval: int, db:
 
     click.echo(f"Database: {db_path}")
 
+    # Initialize the alert dispatcher so collectors can dispatch alerts.
+    # Without this, send_alert() calls from collectors (e.g. node_state's
+    # _dispatch_state_alerts) silently no-op because the global _dispatcher
+    # remains None. Discovered 2026-05-20 when production drains generated
+    # zero alerts despite the collector observing them every 5 minutes.
+    try:
+        from nomad.alerts import init_dispatcher
+        dispatcher = init_dispatcher(config)
+        if dispatcher.backends:
+            backend_names = [b.__class__.__name__ for b in dispatcher.backends]
+            click.echo(
+                f"Alert dispatcher initialized: {len(dispatcher.backends)} "
+                f"backend(s) ({', '.join(backend_names)})"
+            )
+        else:
+            click.echo(
+                "Alert dispatcher initialized (no backends configured -- "
+                "collectors will record events but won't send notifications)"
+            )
+    except Exception as e:
+        # Dispatcher init must not crash collection. Alerts are a
+        # notification feature, not load-bearing for data collection.
+        click.echo(click.style(
+            f"Warning: could not initialize alert dispatcher: {e}",
+            fg="yellow",
+        ))
+        click.echo(
+            "Collectors will run but alerts will not be dispatched. "
+            "Check [alerts.*] configuration in nomad.toml."
+        )
+
     # Initialize collectors
     collectors = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nomad-hpc"
-version = "1.6.4"
+version = "1.6.5"
 description = "A lightweight HPC monitoring and predictive analytics tool"
 readme = "README.md"
 license = {text = "AGPL-3.0-or-later"}

--- a/tests/test_collect_initializes_dispatcher.py
+++ b/tests/test_collect_initializes_dispatcher.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Joao Tonini
+"""Regression test for the dispatcher-not-initialized bug.
+
+`nomad collect` runs collectors that may call send_alert() (via the
+node_state collector's _dispatch_state_alerts). send_alert() looks up
+a global _dispatcher set by init_dispatcher(). If init_dispatcher()
+is never called, send_alert() silently returns {} with only a
+warning-level log.
+
+Production symptom on 2026-05-20: arachne node03 was MIXED+DRAIN for
+16+ hours. The node_state collector captured it every 5 minutes. But
+the alerts table had exactly one row (a manual test alert from the
+night before) and no email was ever sent. Root cause: nomad collect
+never called init_dispatcher().
+
+These tests guard the invariant: after `nomad collect` initializes,
+the global dispatcher must exist so any collector's send_alert() call
+reaches a real dispatcher.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def minimal_config(tmp_path):
+    """Minimal nomad.toml with one collector enabled and SMTP configured."""
+    config = tmp_path / "nomad.toml"
+    config.write_text(f"""
+[general]
+data_dir = "{tmp_path}"
+log_level = "warning"
+
+[database]
+path = "test.db"
+
+[collectors]
+enabled = ["disk"]
+
+[collectors.disk]
+enabled = true
+filesystems = ["/tmp"]
+
+[alerts]
+enabled = true
+min_severity = "warning"
+
+[alerts.email]
+enabled = true
+smtp_server = "127.0.0.1"
+smtp_port = 25
+use_tls = false
+from_address = "test@example.invalid"
+recipients = ["nobody@example.invalid"]
+""")
+    return config
+
+
+def test_collect_calls_init_dispatcher(minimal_config):
+    """REGRESSION: nomad collect must call init_dispatcher() so that
+    collectors' send_alert() calls reach a real dispatcher.
+
+    Before this fix, init_dispatcher was only called from inside
+    ThresholdChecker.__init__(), and nomad collect never instantiated
+    a ThresholdChecker. _dispatcher stayed None for the entire daemon
+    lifetime. Production drains generated zero alerts.
+    """
+    from nomad.cli import cli
+    import nomad.alerts as alerts_module
+
+    real_init = alerts_module.init_dispatcher
+
+    with patch.object(alerts_module, "init_dispatcher",
+                      wraps=real_init) as spy:
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-c", str(minimal_config),
+            "collect", "--once",
+        ])
+
+    assert result.exit_code == 0, (
+        f"collect --once exited with {result.exit_code}. "
+        f"Output:\n{result.output}"
+    )
+    assert spy.called, (
+        "init_dispatcher() was never called from nomad collect. "
+        "This means send_alert() from any collector will silently no-op. "
+        f"Output was:\n{result.output}"
+    )
+
+
+def test_global_dispatcher_exists_after_collect(minimal_config):
+    """REGRESSION: after nomad collect runs setup, get_dispatcher()
+    must return a real dispatcher instance (not None).
+    """
+    import nomad.alerts.dispatcher as dispatcher_module
+    dispatcher_module._dispatcher = None
+
+    from nomad.cli import cli
+    from nomad.alerts import get_dispatcher
+
+    assert get_dispatcher() is None, (
+        "Test setup error: dispatcher was already initialized before collect"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "-c", str(minimal_config),
+        "collect", "--once",
+    ])
+
+    assert result.exit_code == 0, (
+        f"collect --once exited with {result.exit_code}. "
+        f"Output:\n{result.output}"
+    )
+
+    dispatcher = get_dispatcher()
+    assert dispatcher is not None, (
+        "After nomad collect, get_dispatcher() still returns None. "
+        "This means init_dispatcher() was never called and send_alert() "
+        "from any collector will silently no-op.\n"
+        f"Command output was:\n{result.output}"
+    )
+
+    assert dispatcher.backends, (
+        "Dispatcher exists but has zero backends. "
+        "Expected EmailBackend to be initialized from [alerts.email]."
+    )
+    backend_names = [b.__class__.__name__ for b in dispatcher.backends]
+    assert "EmailBackend" in backend_names, (
+        f"Expected EmailBackend in dispatcher, got: {backend_names}"
+    )
+
+
+def test_dispatcher_init_failure_does_not_crash_collect(tmp_path):
+    """If [alerts] config is malformed, collect must continue.
+
+    Alerts are notifications, not load-bearing for data collection.
+    A broken SMTP config should not prevent metric collection.
+    """
+    config = tmp_path / "nomad.toml"
+    config.write_text(f"""
+[general]
+data_dir = "{tmp_path}"
+
+[database]
+path = "test.db"
+
+[collectors]
+enabled = ["disk"]
+
+[collectors.disk]
+enabled = true
+filesystems = ["/tmp"]
+""")
+
+    from nomad.cli import cli
+    import nomad.alerts as alerts_module
+
+    def boom(config):
+        raise RuntimeError("simulated alerts misconfiguration")
+
+    with patch.object(alerts_module, "init_dispatcher", side_effect=boom):
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "-c", str(config),
+            "collect", "--once",
+        ])
+
+    assert result.exit_code == 0, (
+        f"collect crashed with exit code {result.exit_code} when dispatcher "
+        f"init failed. Alerts must not be load-bearing for collection.\n"
+        f"Output:\n{result.output}"
+    )
+    output_lower = result.output.lower()
+    assert ("could not initialize alert dispatcher" in output_lower
+            or "warning" in output_lower), (
+        f"Expected warning about dispatcher init failure. "
+        f"Output:\n{result.output}"
+    )


### PR DESCRIPTION
## Summary

`nomad collect` never called `init_dispatcher()`, so any collector's `send_alert()` calls hit the 'dispatcher is None' branch and silently returned. Production drains generated zero alerts despite the collector observing them every 5 minutes.

## Discovery

2026-05-20: arachne node03 had been MIXED+DRAIN for 16+ hours. The `node_state` collector captured it every 5 minutes (271k+ rows total). The `alerts` table had exactly one entry — the manual test from `nomad test-alerts` the night before. No email ever fired.

## Root cause

`init_dispatcher()` was only called as a side effect of `ThresholdChecker.__init__()`. But `ThresholdChecker` is never instantiated by `nomad collect`. The global `_dispatcher` remained `None` for the entire daemon lifetime. `send_alert()` in `dispatcher.py` correctly handles this case with a warning log — but the warning goes nowhere visible.

## Fix

Initialize the dispatcher in the `collect` command body, right after the database is ensured. Wrapped in try/except so a misconfigured `[alerts]` section can't crash data collection.

## Integration tests

`tests/test_collect_initializes_dispatcher.py` (3 tests) runs `nomad collect --once` end-to-end via CliRunner. These catch the class of bug that mocked unit tests can't catch — wiring between the CLI command and the alerting subsystem.

The v1.6.1 unit tests for `_dispatch_state_alerts()` all pass with the global dispatcher set to None (they used mocks). Only an integration test exercising the real `send_alert` path catches the wiring gap.

## Companion to v1.6.4

v1.6.4 fixed the test command that's supposed to test SMTP wiring. v1.6.5 fixes the actual SMTP wiring being tested. Both bugs had the same root cause: code that appeared correct in unit tests but was disconnected in production.

## Follow-up

Cross-site liveness monitoring (spydur was offline for 2 days with no alert because no NOMAD instance was running there to alert). Architectural gap, not a v1.6.5 bug. Will be tracked as a separate issue.

573 tests pass (570 + 3 new).